### PR TITLE
Restart sequences to work with new_generator_mappings = true setting

### DIFF
--- a/src/main/resources/db/migration/V009.00__restart_sequences.sql
+++ b/src/main/resources/db/migration/V009.00__restart_sequences.sql
@@ -1,0 +1,4 @@
+alter sequence course_id_seq restart with (select coalesce(max(id), 0) from course) + 1 increment by 50;
+alter sequence synchronization_job_run_id_seq restart with (select coalesce(max(id), 0) from synchronization_job_run) + 1 increment by 50;
+alter sequence course_enrollment_status_id_seq restart with (select coalesce(max(id), 0) from course_enrollment_status) + 1 increment by 50;
+alter sequence sync_lock_id_seq restart with (select coalesce(max(id), 0) from sync_lock) + 1 increment by 50;


### PR DESCRIPTION
Hibernate sekvenssin generoinnin asetuksen new_generator_mappings default arvo on muuttunut Hibernate 5:n päivittämisen myötä arvoon true. Tässä restartataan id sekvenssit alkamaan kunkin taulun suurimmasta id:stä lisättynä yhdellä. 

Tässä ihan hyvä artikkeli aiheesta, reviewaajan kannattaa tutustua:
http://tech.zooplus.com/sequences-in-hibernate/