### PR TITLE
https://jira.it.helsinki.fi/browse/MOODI-115 Konfiguroidaan QA-Moodi …

### DIFF
--- a/gradle-build/itest.gradle
+++ b/gradle-build/itest.gradle
@@ -41,8 +41,8 @@ task itest(type: Test) {
         systemProperty 'integration.moodle.wstoken', moodle_ws_token
     }
 
-    if (project.hasProperty('moodle_url')) {
-        systemProperty 'integration.moodle.url', moodle_url
+    if (project.hasProperty('moodle_base_url')) {
+        systemProperty 'integration.moodle.baseUrl', moodle_base_url
     }
 
     testLogging {

--- a/src/itest/java/fi/helsinki/moodi/moodle/AbstractMoodleIntegrationTest.java
+++ b/src/itest/java/fi/helsinki/moodi/moodle/AbstractMoodleIntegrationTest.java
@@ -69,9 +69,9 @@ public abstract class AbstractMoodleIntegrationTest extends AbstractMoodiIntegra
     @Autowired
     protected MoodleCourseBuilder moodleCourseBuilder;
 
-    protected static final String STUDENT_USERNAME = "bar_simp";
+    protected static final String STUDENT_USERNAME = "doo_2";
     protected static final String STUDENT_NOT_IN_MOODLE_USERNAME = "username_of_student_not_in_moodle";
-    protected static final String TEACHER_USERNAME = "mag_simp";
+    protected static final String TEACHER_USERNAME = "doo_1";
 
     protected static final String INTEGRATION_TEST_OODI_FIXTURES_PREFIX = "src/itest/resources/fixtures/oodi/";
 

--- a/src/main/java/fi/helsinki/moodi/config/MoodleConfig.java
+++ b/src/main/java/fi/helsinki/moodi/config/MoodleConfig.java
@@ -50,7 +50,7 @@ public class MoodleConfig {
     public MoodleClient moodleClient() {
         final ObjectMapper objectMapper = objectMapper();
         return new MoodleClient(
-            baseUrl(),
+            restUrl(),
             wstoken(),
             objectMapper,
             moodleRestTemplate(),
@@ -89,8 +89,8 @@ public class MoodleConfig {
         return createRestTemplate(new DefaultHttpRequestRetryHandler(RETRY_COUNT, true));
     }
 
-    private String baseUrl() {
-        return environment.getRequiredProperty("integration.moodle.url");
+    private String restUrl() {
+        return environment.getProperty("integration.moodle.baseUrl") + "/webservice/rest/server.php";
     }
 
     private String wstoken() {

--- a/src/main/java/fi/helsinki/moodi/integration/moodle/MoodleClient.java
+++ b/src/main/java/fi/helsinki/moodi/integration/moodle/MoodleClient.java
@@ -36,6 +36,7 @@ import java.io.IOException;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -50,7 +51,7 @@ public class MoodleClient {
 
     private static final Logger logger = getLogger(MoodleClient.class);
 
-    private final String baseUrl;
+    private final String restUrl;
     private final RestTemplate restTemplate;
     private final RestTemplate readOnlyRestTemplate;
     private final ObjectMapper objectMapper;
@@ -64,12 +65,12 @@ public class MoodleClient {
     private static final String COURSES = "courses";
     private static final String USERS = "users";
 
-    public MoodleClient(String baseUrl,
+    public MoodleClient(String restUrl,
                         String wstoken,
                         ObjectMapper objectMapper,
                         RestTemplate restTemplate,
                         RestTemplate readOnlyRestTemplate) {
-        this.baseUrl = baseUrl;
+        this.restUrl = restUrl;
         this.wstoken = wstoken;
         this.objectMapper = objectMapper;
         this.restTemplate = restTemplate;
@@ -297,10 +298,10 @@ public class MoodleClient {
             final boolean readOnly)
             throws IOException {
 
-        logger.info("Invoke url: {} with params: {}", baseUrl, paramsToString(params));
+        logger.info("Invoke url: {} with params: {}", restUrl, paramsToString(params));
 
         final String body = getRestTemplate(readOnly)
-            .postForObject(baseUrl, new HttpEntity<>(params, createHeaders()), String.class);
+            .postForObject(restUrl, new HttpEntity<>(params, createHeaders()), String.class);
 
         logger.debug("Got response body:\n{}", body);
 
@@ -351,7 +352,8 @@ public class MoodleClient {
     private static String paramsToString(final MultiValueMap<String, String> params) {
         final StringBuilder sb = new StringBuilder();
         for (final String name : params.keySet()) {
-            sb.append(name).append(": ").append(params.get(name));
+            List<String> values = name.equals("wstoken") ? Arrays.asList("xxxx") : params.get(name);
+            sb.append(name).append(": ").append(values).append("\n");
         }
 
         return sb.toString();

--- a/src/main/java/fi/helsinki/moodi/service/util/MapperService.java
+++ b/src/main/java/fi/helsinki/moodi/service/util/MapperService.java
@@ -55,6 +55,7 @@ public class MapperService {
         return getMoodleRole(ROLE_TEACHER);
     }
 
+    // Also known as the synced role
     public long getMoodiRoleId() {
         return getMoodleRole(ROLE_MOODI);
     }

--- a/src/main/resources/config/application-dev.yml
+++ b/src/main/resources/config/application-dev.yml
@@ -12,8 +12,7 @@ spring:
 
 integration:
   moodle:
-    baseUrl: https://moodi-2-moodle.student.helsinki.fi/moodlecurrent
-    url: https://moodi-2-moodle.student.helsinki.fi/moodlecurrent/webservice/rest/server.php
+    baseUrl: https://moodi-2-moodle-20.student.helsinki.fi/moodlecurrent
   oodi.url: https://esbmt2.it.helsinki.fi/secure/doo-oodi/dev/testdb
   iam.mock: true
 

--- a/src/main/resources/config/application-local.yml
+++ b/src/main/resources/config/application-local.yml
@@ -10,8 +10,7 @@ spring:
 
 integration:
   moodle:
-    baseUrl: https://moodi-2-moodle.student.helsinki.fi/moodlecurrent
-    url: https://moodi-2-moodle.student.helsinki.fi/moodlecurrent/webservice/rest/server.php
+    baseUrl: https://moodi-2-moodle-20.student.helsinki.fi/moodlecurrent
   oodi.url: https://esbmt2.it.helsinki.fi/secure/doo-oodi/dev/testdb
   iam.mock: true
 

--- a/src/main/resources/config/application-prod.yml
+++ b/src/main/resources/config/application-prod.yml
@@ -13,6 +13,9 @@ spring:
 integration:
   moodle:
     baseUrl: https://moodle.helsinki.fi
-    url: https://moodle.helsinki.fi/webservice/rest/server.php
   oodi.url: https://esbmt1.it.helsinki.fi/secure/doo-oodi/v1/productiondb
   iam.url: https://esbmt1.it.helsinki.fi
+
+mapper.moodle.defaultCategory: 73
+# Also known as the synced role
+mapper.moodle.role.moodi: 11

--- a/src/main/resources/config/application-qa.yml
+++ b/src/main/resources/config/application-qa.yml
@@ -12,7 +12,6 @@ spring:
 
 integration:
   moodle:
-    baseUrl: https://moodi-2-moodle.student.helsinki.fi/moodlecurrent
-    url: https://moodi-2-moodle.student.helsinki.fi/moodlecurrent/webservice/rest/server.php
+    baseUrl: https://moodi-2-moodle-20.student.helsinki.fi/moodlecurrent
   oodi.url: https://esbmt1.it.helsinki.fi/secure/doo-oodi/v1/productiondb
   iam.url: https://esbmt1.it.helsinki.fi

--- a/src/main/resources/config/application-test.yml
+++ b/src/main/resources/config/application-test.yml
@@ -13,8 +13,7 @@ auth.enabled: true
 
 integration:
   moodle:
-    baseUrl: https://moodi-2-moodle.student.helsinki.fi/moodlecurrent
-    url: https://moodi-2-moodle.student.helsinki.fi/moodlecurrent/webservice/rest/server.php
+    baseUrl: https://moodi-2-moodle-20.student.helsinki.fi/moodlecurrent
     wstoken: xxxx1234
   oodi.url: https://esbmt2.it.helsinki.fi/doo-oodi/dev/testdb
   iam.url: https://esbmt2.it.helsinki.fi

--- a/src/main/resources/config/application.yml
+++ b/src/main/resources/config/application.yml
@@ -19,14 +19,15 @@ httpClient:
 
 oodi.enrollmentApprovedStatusCodes: 2, 3, 7, 8
 
-mapper.moodle.defaultCategory: 73
+mapper.moodle.defaultCategory: 2
 
 #
 # Map application roles to Moodle's internal role IDs.
 #
 mapper.moodle.role.teacher: 3
 mapper.moodle.role.student: 5
-mapper.moodle.role.moodi: 11
+# Also known as the synced role
+mapper.moodle.role.moodi: 10
 
 synchronize.FULL.enabled: true
 synchronize.INCREMENTAL.enabled: false

--- a/src/test/java/fi/helsinki/moodi/service/importing/MoodleCourseBuilderTest.java
+++ b/src/test/java/fi/helsinki/moodi/service/importing/MoodleCourseBuilderTest.java
@@ -62,7 +62,7 @@ public class MoodleCourseBuilderTest extends AbstractMoodiIntegrationTest {
     private static final Integer DESCRIPTION_1_ID = 10;
     private static final Integer DESCRIPTION_2_ID = 20;
     private static final Integer DESCRIPTION_3_ID = 30;
-    private static final String MOODLE_CATEGORY_ID = "73";
+    private static final String MOODLE_CATEGORY_ID = "2";
 
     @Autowired
     private MoodleCourseBuilder moodleCourseBuilder;

--- a/src/test/java/fi/helsinki/moodi/service/synchronize/process/UserSynchronizationActionResolverTest.java
+++ b/src/test/java/fi/helsinki/moodi/service/synchronize/process/UserSynchronizationActionResolverTest.java
@@ -48,6 +48,9 @@ public class UserSynchronizationActionResolverTest extends AbstractMoodiIntegrat
 
     private static final Long MOODLE_USER_ID = 1L;
     private static final Long MOODLE_COURSE_ID = 2L;
+    private static final Long TEACHER_ROLE = 3L;
+    private static final Long STUDENT_ROLE = 5L;
+    private static final Long SYNCED_ROLE = 10L;
 
     @Autowired
     private UserSynchronizationActionResolver userSynchronizationActionResolver;
@@ -58,7 +61,7 @@ public class UserSynchronizationActionResolverTest extends AbstractMoodiIntegrat
 
         userSynchronizationActionResolver.enrichWithActions(item);
 
-        assertActions(item, ImmutableMap.of(ADD_ENROLLMENT, newArrayList(5L, 11L)));
+        assertActions(item, ImmutableMap.of(ADD_ENROLLMENT, newArrayList(STUDENT_ROLE, SYNCED_ROLE)));
     }
 
     @Test
@@ -76,7 +79,7 @@ public class UserSynchronizationActionResolverTest extends AbstractMoodiIntegrat
 
         userSynchronizationActionResolver.enrichWithActions(item);
 
-        assertActions(item, ImmutableMap.of(ADD_ENROLLMENT, newArrayList(3L, 11L)));
+        assertActions(item, ImmutableMap.of(ADD_ENROLLMENT, newArrayList(TEACHER_ROLE, SYNCED_ROLE)));
     }
 
     @Test
@@ -86,87 +89,87 @@ public class UserSynchronizationActionResolverTest extends AbstractMoodiIntegrat
 
         userSynchronizationActionResolver.enrichWithActions(item);
 
-        assertActions(item, ImmutableMap.of(ADD_ENROLLMENT, newArrayList(3L, 5L, 11L)));
+        assertActions(item, ImmutableMap.of(ADD_ENROLLMENT, newArrayList(TEACHER_ROLE, STUDENT_ROLE, SYNCED_ROLE)));
     }
 
     @Test
     public void thatSuspendEnrollmentActionIsResolvedIfAlreadyInDefaultRoleAndNotApproved() {
         UserSynchronizationItem item = getStudentUserSynchronizationItem(false);
-        item.withMoodleUserEnrollments(getMoodleUserEnrollments(newArrayList(11L), MOODLE_COURSE_ID));
+        item.withMoodleUserEnrollments(getMoodleUserEnrollments(newArrayList(SYNCED_ROLE), MOODLE_COURSE_ID));
 
         userSynchronizationActionResolver.enrichWithActions(item);
 
-        assertActions(item, ImmutableMap.of(SUSPEND_ENROLLMENT, newArrayList(11L)));
+        assertActions(item, ImmutableMap.of(SUSPEND_ENROLLMENT, newArrayList(SYNCED_ROLE)));
     }
 
     @Test
     public void thatAddTeacherRoleActionIsResolvedIfAlreadyInDefaultRole() {
         UserSynchronizationItem item = getTeacherUserSynchronizationItem();
-        item.withMoodleUserEnrollments(getMoodleUserEnrollments(newArrayList(11L)));
+        item.withMoodleUserEnrollments(getMoodleUserEnrollments(newArrayList(SYNCED_ROLE)));
 
         userSynchronizationActionResolver.enrichWithActions(item);
 
-        assertActions(item, ImmutableMap.of(ADD_ROLES, newArrayList(3L)));
+        assertActions(item, ImmutableMap.of(ADD_ROLES, newArrayList(TEACHER_ROLE)));
     }
 
     @Test
     public void thatAddDefaultRoleActionIsResolvedForStudentIfEnrolledInMoodleWithoutDefaultRole() {
         UserSynchronizationItem item = getStudentUserSynchronizationItem(true);
-        item.withMoodleUserEnrollments(getMoodleUserEnrollments(newArrayList(5L)));
+        item.withMoodleUserEnrollments(getMoodleUserEnrollments(newArrayList(STUDENT_ROLE)));
 
         userSynchronizationActionResolver.enrichWithActions(item);
 
-        assertActions(item, ImmutableMap.of(ADD_ROLES, newArrayList(11L)));
+        assertActions(item, ImmutableMap.of(ADD_ROLES, newArrayList(SYNCED_ROLE)));
     }
 
     @Test
     public void thatAddDefaultRoleActionIsResolvedForTeacherIfEnrolledInMoodleWithoutDefaultRole() {
         UserSynchronizationItem item = getTeacherUserSynchronizationItem();
-        item.withMoodleUserEnrollments(getMoodleUserEnrollments(newArrayList(3L)));
+        item.withMoodleUserEnrollments(getMoodleUserEnrollments(newArrayList(TEACHER_ROLE)));
 
         userSynchronizationActionResolver.enrichWithActions(item);
 
-        assertActions(item, ImmutableMap.of(ADD_ROLES, newArrayList(11L)));
+        assertActions(item, ImmutableMap.of(ADD_ROLES, newArrayList(SYNCED_ROLE)));
     }
 
     @Test
     public void thatStudentRoleIsRemoved() {
         UserSynchronizationItem item = getStudentUserSynchronizationItem(false);
-        item.withMoodleUserEnrollments(getMoodleUserEnrollments(newArrayList(3L, 5L, 11L)));
+        item.withMoodleUserEnrollments(getMoodleUserEnrollments(newArrayList(TEACHER_ROLE, STUDENT_ROLE, SYNCED_ROLE)));
 
         userSynchronizationActionResolver.enrichWithActions(item);
 
-        assertActions(item, ImmutableMap.of(REMOVE_ROLES, newArrayList(5L)));
+        assertActions(item, ImmutableMap.of(REMOVE_ROLES, newArrayList(STUDENT_ROLE)));
     }
 
     @Test
     public void thatStudentIsSuspendedAndStudentRoleIsRemoved() {
         UserSynchronizationItem item = getStudentUserSynchronizationItem(false);
-        item.withMoodleUserEnrollments(getMoodleUserEnrollments(newArrayList(5L, 11L), MOODLE_COURSE_ID));
+        item.withMoodleUserEnrollments(getMoodleUserEnrollments(newArrayList(STUDENT_ROLE, SYNCED_ROLE), MOODLE_COURSE_ID));
 
         userSynchronizationActionResolver.enrichWithActions(item);
 
         assertActions(item, ImmutableMap.of(
-                SUSPEND_ENROLLMENT, newArrayList(11L),
-                REMOVE_ROLES, newArrayList(5L)));
+                SUSPEND_ENROLLMENT, newArrayList(SYNCED_ROLE),
+                REMOVE_ROLES, newArrayList(STUDENT_ROLE)));
     }
 
     @Test
     public void thatStudentIsReactivatedAndStudentRoleIsAdded() {
         UserSynchronizationItem item = getStudentUserSynchronizationItem(true);
-        item.withMoodleUserEnrollments(getMoodleUserEnrollments(newArrayList(11L)));
+        item.withMoodleUserEnrollments(getMoodleUserEnrollments(newArrayList(SYNCED_ROLE)));
 
         userSynchronizationActionResolver.enrichWithActions(item);
 
         assertActions(item, ImmutableMap.of(
-                REACTIVATE_ENROLLMENT, newArrayList(5L),
-                ADD_ROLES, newArrayList(5L)));
+                REACTIVATE_ENROLLMENT, newArrayList(STUDENT_ROLE),
+                ADD_ROLES, newArrayList(STUDENT_ROLE)));
     }
 
     @Test
     public void thatTeacherRoleIsNeverRemoved() {
         UserSynchronizationItem item = getStudentUserSynchronizationItem(true);
-        item.withMoodleUserEnrollments(getMoodleUserEnrollments(newArrayList(3L, 5L, 11L)));
+        item.withMoodleUserEnrollments(getMoodleUserEnrollments(newArrayList(TEACHER_ROLE, STUDENT_ROLE, SYNCED_ROLE)));
 
         userSynchronizationActionResolver.enrichWithActions(item);
 

--- a/src/test/java/fi/helsinki/moodi/service/util/MapperServiceTest.java
+++ b/src/test/java/fi/helsinki/moodi/service/util/MapperServiceTest.java
@@ -30,7 +30,7 @@ public class MapperServiceTest extends AbstractMoodiIntegrationTest {
 
     @Test
     public void getDefaultMoodleCategory() throws Exception {
-        assertEquals("73", mapperService.getDefaultCategory());
+        assertEquals("2", mapperService.getDefaultCategory());
     }
 
     @Test

--- a/src/test/java/fi/helsinki/moodi/test/AbstractMoodiIntegrationTest.java
+++ b/src/test/java/fi/helsinki/moodi/test/AbstractMoodiIntegrationTest.java
@@ -118,7 +118,7 @@ public abstract class AbstractMoodiIntegrationTest {
     }
 
     protected String getMoodleRestUrl() {
-        return environment.getProperty("integration.moodle.url");
+        return environment.getProperty("integration.moodle.baseUrl") + "/webservice/rest/server.php";
     }
 
     protected String getOodiCourseUnitRealisationRequestUrl(final long realisationId) {
@@ -331,7 +331,7 @@ public abstract class AbstractMoodiIntegrationTest {
                 "wstoken=xxxx1234&wsfunction=core_course_create_courses&moodlewsrestformat=json&courses%5B0%5D%5Bidnumber%5D=" +
                 EXPECTED_COURSE_ID +
                 "&courses%5B0%5D%5Bfullname%5D=Lapsuus+ja+yhteiskunta&courses%5B0%5D%5Bshortname%5D=Lapsuus++" + realisationId +
-                "&courses%5B0%5D%5Bcategoryid%5D=73" +
+                "&courses%5B0%5D%5Bcategoryid%5D=2" +
                 "&courses%5B0%5D%5Bsummary%5D=Description+1+%28fi%29+Description+2+%28fi%29&courses%5B0%5D%5Bvisible%5D=0" +
                 "&courses%5B0%5D%5Bstartdate%5D=1564952400&courses%5B0%5D%5Benddate%5D=1575493200" + // Oodi end date plus one month
                 "&courses%5B0%5D%5Bcourseformatoptions%5D%5B0%5D%5Bname%5D=numsections&courses%5B0%5D%5Bcourseformatoptions%5D%5B0%5D%5Bvalue%5D=7"))

--- a/src/test/resources/fixtures/moodle/get-enrolled-users.json
+++ b/src/test/resources/fixtures/moodle/get-enrolled-users.json
@@ -8,7 +8,7 @@
         "shortname": "o-student"
       },
       {
-        "roleid": 11,
+        "roleid": 10,
         "name": "Moodi synced",
         "shortname": "o-moodi"
       }
@@ -35,7 +35,7 @@
         "shortname": "o-student"
       },
       {
-        "roleid": 11,
+        "roleid": 10,
         "name": "Moodi synced",
         "shortname": "o-moodi"
       }
@@ -57,7 +57,7 @@
         "shortname": "o-student"
       },
       {
-        "roleid": 11,
+        "roleid": 10,
         "name": "Moodi synced",
         "shortname": "o-moodi"
       }
@@ -72,7 +72,7 @@
         "shortname": "o-student"
       },
       {
-        "roleid": 11,
+        "roleid": 10,
         "name": "Moodi synced",
         "shortname": "o-moodi"
       }
@@ -87,14 +87,14 @@
         "shortname": "o-student"
       },
       {
-        "roleid": 11,
+        "roleid": 10,
         "name": "Moodi synced",
         "shortname": "o-moodi"
       }
     ]
   },
   {
-    "id": 11,
+    "id": 10,
     "roles": [
       {
         "roleid": 5,
@@ -102,7 +102,7 @@
         "shortname": "o-student"
       },
       {
-        "roleid": 11,
+        "roleid": 10,
         "name": "Moodi synced",
         "shortname": "o-moodi"
       }
@@ -117,7 +117,7 @@
         "shortname": "o-student"
       },
       {
-        "roleid": 11,
+        "roleid": 10,
         "name": "Moodi synced",
         "shortname": "o-moodi"
       }
@@ -132,7 +132,7 @@
         "shortname": "o-teacher"
       },
       {
-        "roleid": 11,
+        "roleid": 10,
         "name": "Moodi synced",
         "shortname": "o-moodi"
       }


### PR DESCRIPTION
…juttelemaan uuden QA-Moodlepalvelimen kanssa

- Changed Moodle QA server name from moodi-2-moodle.student.helsinki.fi to moodi-2-moodle-20.student.helsinki.fi
- Simplified Moodle URL config and clarified related terminology.
- Clarified REST call logging and masked wstoken out.
- Default values for default category and synced role id are now those of the new Moodle QA environment, and THE prod environment overrides them.

https://jira.it.helsinki.fi/browse/MOODI-105 Muutetaan integraatiotestien käyttämät käyttäjätunnukset
- Changed integration test users bar_simp to doo_2 and mag_simp to doo_1.