### PR TITLE
https://jira.it.helsinki.fi/browse/MOODI-125 Paranneltu health check …

### DIFF
--- a/src/main/java/fi/helsinki/moodi/MoodiHealthIndicator.java
+++ b/src/main/java/fi/helsinki/moodi/MoodiHealthIndicator.java
@@ -49,13 +49,13 @@ public class MoodiHealthIndicator implements HealthIndicator {
     // - an important API action has failed within 30 minutes, and has not succeeded since.
     @Override
     public Health health() {
-        LocalDateTime now = timeService.getCurrentDateTime();
+        LocalDateTime now = timeService.getCurrentUTCDateTime(); // DB timestamps are in UTC.
         try {
             Optional<SynchronizationJobRun> searched = synchronizationJobRunService.findLatestCompletedJob();
             if (searched.isPresent()) {
                 SynchronizationJobRun latest = searched.get();
                 if (latest.completed == null || latest.completed.isBefore(now.minusHours(MAX_HOURS_SINCE_COMPLETED_SYNC))) {
-                    return indicateError(String.format("No job completed in %d hours. Latest job completed at %s",
+                    return indicateError(String.format("No job completed in %d hours. Latest job completed at %s UTC",
                         MAX_HOURS_SINCE_COMPLETED_SYNC, latest.completed));
                 }
             } else {
@@ -105,7 +105,7 @@ public class MoodiHealthIndicator implements HealthIndicator {
         public Error(String error, Exception e) {
             this.message = error;
             this.exception = e;
-            this.when = timeService.getCurrentDateTime();
+            this.when = timeService.getCurrentUTCDateTime(); // This class uses UTC, because DB timestamps are in UTC.
         }
     }
 }

--- a/src/test/java/fi/helsinki/moodi/web/HealthCheckTest.java
+++ b/src/test/java/fi/helsinki/moodi/web/HealthCheckTest.java
@@ -33,6 +33,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 
 import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.util.Optional;
 
 import static org.mockito.ArgumentMatchers.*;
@@ -112,7 +113,8 @@ public class HealthCheckTest extends AbstractMoodiIntegrationTest {
         mockMvc.perform(get("/health"))
             .andExpect(status().is5xxServerError())
             .andExpect(jsonPath("$.status").value("DOWN"))
-            .andExpect(jsonPath("$.details.moodi.details.error").value("No job completed in 3 hours. Latest job completed at " + fourHoursAgo));
+            .andExpect(jsonPath("$.details.moodi.details.error")
+                .value(String.format("No job completed in 3 hours. Latest job completed at %s UTC", fourHoursAgo)));
     }
 
     @Test
@@ -143,7 +145,7 @@ public class HealthCheckTest extends AbstractMoodiIntegrationTest {
     }
 
     private LocalDateTime setupJobRunHoursAgo(int hours) {
-        LocalDateTime hoursAgo = LocalDateTime.now().minusHours(hours);
+        LocalDateTime hoursAgo = LocalDateTime.now(ZoneOffset.UTC).minusHours(hours);
         setupLastRun(getRun(hoursAgo));
 
         setTime(0);
@@ -151,7 +153,7 @@ public class HealthCheckTest extends AbstractMoodiIntegrationTest {
     }
 
     private void setTime(int diffMinutes) {
-        when(timeService.getCurrentDateTime()).thenReturn(LocalDateTime.now().plusMinutes(diffMinutes));
+        when(timeService.getCurrentUTCDateTime()).thenReturn(LocalDateTime.now(ZoneOffset.UTC).plusMinutes(diffMinutes));
     }
 
     private void setupLastRun(Optional<SynchronizationJobRun> jobRun) {


### PR DESCRIPTION
…hälyttää turhaan

Now using UTC time in MoodiHealthIndicator, as UTC is used in DB timestamps.