### PR TITLE
https://jira.it.helsinki.fi/browse/MOODI-126 Health checkin tulisi hu…

### DIFF
--- a/src/main/java/fi/helsinki/moodi/integration/iam/IAMRestClient.java
+++ b/src/main/java/fi/helsinki/moodi/integration/iam/IAMRestClient.java
@@ -42,7 +42,7 @@ public class IAMRestClient implements IAMClient {
         this.restTemplate = restTemplate;
     }
 
-    @Cacheable(value = "iam-client.student-username-by-student-number", unless = "#result == null")
+    @Cacheable(value = "iam-client.student-username-by-student-number", unless = "#result == null or #result.size()==0")
     public List<String> getStudentUserNameList(final String studentNumber) {
         logger.debug("Get student username by student number {}", studentNumber);
 
@@ -67,7 +67,7 @@ public class IAMRestClient implements IAMClient {
         }
     }
 
-    @Cacheable(value = "iam-client.teacher-username-by-teacher-id", unless = "#result == null")
+    @Cacheable(value = "iam-client.teacher-username-by-teacher-id", unless = "#result == null or #result.size()==0")
     public List<String> getTeacherUserNameList(final String employeeNumber) {
         logger.debug("Get teacher username by teacher id {}", employeeNumber);
 

--- a/src/main/java/fi/helsinki/moodi/integration/moodle/MoodleClient.java
+++ b/src/main/java/fi/helsinki/moodi/integration/moodle/MoodleClient.java
@@ -85,7 +85,7 @@ public class MoodleClient {
         try {
             return execute(params, new TypeReference<List<MoodleFullCourse>>() {}, DEFAULT_EVALUATION, true);
         } catch (Exception e) {
-            return handleException("Error executing method: core_course_get_courses", e);
+            return handleException("Error executing method: getCourses", e);
         }
     }
 
@@ -124,7 +124,7 @@ public class MoodleClient {
                 .map(s -> s.id)
                 .orElse(null);
         } catch (Exception e) {
-            return handleException("Error executing method: importCourse", e);
+            return handleException("Error executing method: createCourse", e);
         }
     }
 
@@ -179,7 +179,7 @@ public class MoodleClient {
                 .findFirst()
                 .orElse(null);
         } catch (Exception e) {
-            return handleException("Error executing method: getUsers", e);
+            return handleException("Error executing method: getUser", e);
         }
     }
 
@@ -223,7 +223,7 @@ public class MoodleClient {
         try {
             return execute(params, new TypeReference<List<MoodleUserEnrollments>>() {}, DEFAULT_EVALUATION, true);
         } catch (Exception e) {
-            return handleException("Error executing method: getUsers", e);
+            return handleException("Error executing method: getEnrolledUsers", e);
         }
     }
 

--- a/src/main/java/fi/helsinki/moodi/scheduled/FullSynchronizationJob.java
+++ b/src/main/java/fi/helsinki/moodi/scheduled/FullSynchronizationJob.java
@@ -49,7 +49,7 @@ public class FullSynchronizationJob {
         }
     }
 
-    private boolean isEnabled() {
+    public boolean isEnabled() {
         final String key = String.format("synchronize.%s.enabled", FULL);
         return environment.getRequiredProperty(key, Boolean.class);
     }

--- a/src/main/java/fi/helsinki/moodi/scheduled/IncrementalSynchronizationJob.java
+++ b/src/main/java/fi/helsinki/moodi/scheduled/IncrementalSynchronizationJob.java
@@ -51,6 +51,7 @@ public class IncrementalSynchronizationJob {
 
     // Has been disabled since 9/2016, as Oodi API did not really support getting enrollment updates.
     // Do not enable until that is working AND Incremental sync has been implemented for Sisu.
+    // If you enable this, remember to modify MoodiHealthIndicator.
     private boolean isEnabled() {
         final String key = String.format("synchronize.%s.enabled", INCREMENTAL);
         return false;

--- a/src/main/java/fi/helsinki/moodi/service/synchronize/process/ActionResolver.java
+++ b/src/main/java/fi/helsinki/moodi/service/synchronize/process/ActionResolver.java
@@ -35,8 +35,8 @@ public final class ActionResolver {
                 return Action.SYNCHRONIZE;
             case COURSE_NOT_PUBLIC:
             case COURSE_ENDED:
-                return Action.REMOVE;
             case MOODLE_COURSE_NOT_FOUND:
+                return Action.REMOVE;
             case LOCKED:
             default:
                 return Action.SKIP;

--- a/src/main/resources/config/application.yml
+++ b/src/main/resources/config/application.yml
@@ -18,7 +18,7 @@ httpClient:
   # Defines the socket timeout (SO_TIMEOUT) in milliseconds,
   # which is the timeout for waiting for data  or, put differently,
   # a maximum period inactivity between two consecutive data packets).
-  socketTimeout: 3000
+  socketTimeout: 15000
 
 oodi.enrollmentApprovedStatusCodes: 2, 3, 7, 8
 

--- a/src/test/java/fi/helsinki/moodi/scheduled/FullSynchronizationJobTest.java
+++ b/src/test/java/fi/helsinki/moodi/scheduled/FullSynchronizationJobTest.java
@@ -310,12 +310,12 @@ public class FullSynchronizationJobTest extends AbstractSynchronizationJobTest {
     }
 
     @Test
-    public void thatIfUsernameIsNotFoundFromIAMSynchronizationIsNotCompleted() {
+    public void thatIfUsernameIsNotFoundFromIAMSynchronizationIsSuccessful() {
         ExpectationsForUserThatCannotBeMappedToMoodleUser expectations = () -> {
             expectFindStudentRequestToIAMAndRespondWithEmptyResult(STUDENT_NUMBER);
         };
 
-        testSynchronizationForUserThatCanNotBeMappedToMoodleUser(expectations, UserSynchronizationItemStatus.USERNAME_NOT_FOUND);
+        testSynchronizationForUserThatCanNotBeMappedToMoodleUser(expectations, UserSynchronizationItemStatus.SUCCESS);
     }
 
     @Test


### PR DESCRIPTION
…omioida sync-ajon status

- Now health check verifies that last sync job run was a success.
- No longer caching empty IAM responses.
- Increased HTTP client timeout from 3 to 15 seconds, as some calls were taking 4 seconds.
- Improved error logging in MoodleClient.
- Now, if a course is not found in Moodle during sync, it will be marked as removed in Moodi.
- Now, if a user is not found in IAM during sync, it will not fail the sync run. Student/employee number is logged.
- Also logging user name for users not found in Moodle during sync.
- MoodiHealthIndicator is no longer reporting an error on Dev due to sync job not being configured to run.