### PR TITLE
https://jira.it.helsinki.fi/browse/MOODI-122 Poistettujen ilmoittautu…

### DIFF
--- a/src/main/java/fi/helsinki/moodi/integration/moodle/MoodleRole.java
+++ b/src/main/java/fi/helsinki/moodi/integration/moodle/MoodleRole.java
@@ -29,4 +29,10 @@ public final class MoodleRole {
 
     @JsonProperty("shortname")
     public String shortName;
+
+    public MoodleRole() {}
+
+    public MoodleRole(long roleId) {
+        this.roleId = roleId;
+    }
 }

--- a/src/main/java/fi/helsinki/moodi/service/synchronize/process/SynchronizingProcessor.java
+++ b/src/main/java/fi/helsinki/moodi/service/synchronize/process/SynchronizingProcessor.java
@@ -276,8 +276,7 @@ public class SynchronizingProcessor extends AbstractProcessor {
         // https://jira.it.helsinki.fi/browse/MOODI-122 process Moodle users that do not appear in StudyRegistry.
         Stream<UserSynchronizationItem> moodleUsersNotInStudyRegistry =
             moodleEnrollmentsByUserId.values().stream().filter(m -> m.username != null & !studyRegistryStudentUsernames.contains(m.username))
-            .map(m -> new UserSynchronizationItem(m))
-            .map(i -> i.withMoodleCourseId(item.getCourse().moodleId));
+            .map(m -> new UserSynchronizationItem(m).withMoodleCourseId(item.getCourse().moodleId));
 
         return Stream.concat(
             moodleUsersNotInStudyRegistry,

--- a/src/main/java/fi/helsinki/moodi/service/synchronize/process/SynchronizingProcessor.java
+++ b/src/main/java/fi/helsinki/moodi/service/synchronize/process/SynchronizingProcessor.java
@@ -41,6 +41,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -48,6 +49,7 @@ import java.util.stream.Stream;
 
 import static com.google.common.collect.Lists.newArrayList;
 import static fi.helsinki.moodi.service.synchronize.process.UserSynchronizationItem.UserSynchronizationItemStatus.*;
+import static org.springframework.util.CollectionUtils.isEmpty;
 
 /**
  * Processor implementation that synchronizes courses.
@@ -165,7 +167,7 @@ public class SynchronizingProcessor extends AbstractProcessor {
                 .collect(Collectors.toList());
 
         } catch (Exception e) {
-            logger.error(String.format("Error when executing action %s", e));
+            logger.error(String.format("Error when executing action %s", e), e);
             return actions.stream()
                 .map(UserSynchronizationAction::withErrorStatus)
                 .collect(Collectors.toList());
@@ -269,9 +271,20 @@ public class SynchronizingProcessor extends AbstractProcessor {
                 UserSynchronizationItem::combine))
             .values();
 
+        Set<String> studyRegistryStudentUsernames = course.students.stream().map(s -> s.userName).collect(Collectors.toSet());
+
+        // https://jira.it.helsinki.fi/browse/MOODI-122 process Moodle users that do not appear in StudyRegistry.
+        Stream<UserSynchronizationItem> moodleUsersNotInStudyRegistry =
+            moodleEnrollmentsByUserId.values().stream().filter(m -> m.username != null & !studyRegistryStudentUsernames.contains(m.username))
+            .map(m -> new UserSynchronizationItem(m))
+            .map(i -> i.withMoodleCourseId(item.getCourse().moodleId));
+
         return Stream.concat(
-            combinedUncompletedItems.stream().map(enrichWithMoodleUserEnrollments(moodleEnrollmentsByUserId)),
-            completedItems.stream()).collect(Collectors.toList());
+            moodleUsersNotInStudyRegistry,
+            Stream.concat(
+                combinedUncompletedItems.stream().map(enrichWithMoodleUserEnrollments(moodleEnrollmentsByUserId)),
+                completedItems.stream())
+        ).collect(Collectors.toList());
     }
 
     private Function<UserSynchronizationItem, UserSynchronizationItem> enrichWithMoodleUserEnrollments(final Map<Long,
@@ -286,6 +299,7 @@ public class SynchronizingProcessor extends AbstractProcessor {
         if (item.getStudent() != null) {
             if (item.getStudent().userName == null) {
                 usernames = getUsernameList(item.getStudent());
+                item.getStudent().userName = isEmpty(usernames) ? null : usernames.get(0);
             } else {
                 usernames.add(item.getStudent().userName);
             }
@@ -293,6 +307,7 @@ public class SynchronizingProcessor extends AbstractProcessor {
         if (item.getTeacher() != null) {
             if (item.getTeacher().userName == null) {
                 usernames = getUsernameList(item.getTeacher());
+                item.getTeacher().userName = isEmpty(usernames) ? null : usernames.get(0);
             } else {
                 usernames.add(item.getTeacher().userName);
             }

--- a/src/main/java/fi/helsinki/moodi/service/synchronize/process/UserSynchronizationItem.java
+++ b/src/main/java/fi/helsinki/moodi/service/synchronize/process/UserSynchronizationItem.java
@@ -51,6 +51,12 @@ public class UserSynchronizationItem {
         this.student = student;
     }
 
+    public UserSynchronizationItem(MoodleUserEnrollments moodleUserEnrollments) {
+        this.moodleUserEnrollments = moodleUserEnrollments;
+        this.moodleUser = new MoodleUser();
+        this.moodleUser.id = moodleUserEnrollments.id;
+    }
+
     public UserSynchronizationItem(StudyRegistryTeacher teacher) {
         this.teacher = teacher;
     }

--- a/src/main/resources/config/application.yml
+++ b/src/main/resources/config/application.yml
@@ -14,7 +14,7 @@ management:
 
 httpClient:
   # Determines the timeout in milliseconds until a connection is established.
-  connectTimeout: 3000
+  connectTimeout: 9000
   # Defines the socket timeout (SO_TIMEOUT) in milliseconds,
   # which is the timeout for waiting for data  or, put differently,
   # a maximum period inactivity between two consecutive data packets).

--- a/src/test/java/fi/helsinki/moodi/scheduled/AbstractSynchronizationJobTest.java
+++ b/src/test/java/fi/helsinki/moodi/scheduled/AbstractSynchronizationJobTest.java
@@ -128,7 +128,8 @@ public abstract class AbstractSynchronizationJobTest extends AbstractMoodiIntegr
 
         expectGetEnrollmentsRequestToMoodle(
             MOODLE_COURSE_ID,
-            getEnrollmentsResponse(STUDENT_USER_MOODLE_ID, MOODLE_COURSE_ID, mapperService.getTeacherRoleId(), mapperService.getMoodiRoleId()));
+            getEnrollmentsResponse(STUDENT_USER_MOODLE_ID, STUDENT_USERNAME + USERNAME_SUFFIX,
+                MOODLE_COURSE_ID, mapperService.getTeacherRoleId(), mapperService.getMoodiRoleId()));
 
         expectFindUsersRequestsToIAMAndMoodle();
 
@@ -158,7 +159,8 @@ public abstract class AbstractSynchronizationJobTest extends AbstractMoodiIntegr
 
         expectGetEnrollmentsRequestToMoodle(
             MOODLE_COURSE_ID,
-            getEnrollmentsResponse(STUDENT_USER_MOODLE_ID, MOODLE_COURSE_ID, mapperService.getStudentRoleId(), mapperService.getMoodiRoleId()));
+            getEnrollmentsResponse(STUDENT_USER_MOODLE_ID, STUDENT_USERNAME + USERNAME_SUFFIX,
+                MOODLE_COURSE_ID, mapperService.getStudentRoleId(), mapperService.getMoodiRoleId()));
 
         expectFindUsersRequestsToIAMAndMoodle();
 

--- a/src/test/java/fi/helsinki/moodi/scheduled/FullSyncJobSisuTest.java
+++ b/src/test/java/fi/helsinki/moodi/scheduled/FullSyncJobSisuTest.java
@@ -74,7 +74,8 @@ public class FullSyncJobSisuTest extends AbstractMoodiIntegrationTest {
 
         setupMoodleGetCourseResponse(MOODLE_COURSE_ID_1);
         // Two users are already enrolled with student and synced roles.
-        // One of them is not enrolled for the course, and the other not in Sisu at all.
+        // One of them now gets returned from Sisu with a non-enrolled status, and the
+        // other one does not get returned from Sisu at all, as someone has totally removed the whole enrollment from Sisu.
         expectGetEnrollmentsRequestToMoodle(
             MOODLE_COURSE_ID_1,
             getMoodleUserEnrollments((int) MOODLE_USER_NOT_ENROLLED, MOODLE_USERNAME_NOT_ENROLLED, MOODLE_COURSE_ID_1,

--- a/src/test/java/fi/helsinki/moodi/scheduled/FullSyncJobSisuTest.java
+++ b/src/test/java/fi/helsinki/moodi/scheduled/FullSyncJobSisuTest.java
@@ -73,11 +73,15 @@ public class FullSyncJobSisuTest extends AbstractMoodiIntegrationTest {
         setUpMockSisuAndPrefetchCourses();
 
         setupMoodleGetCourseResponse(MOODLE_COURSE_ID_1);
-        // One user is already enrolled with student and synced roles.
+        // Two users are already enrolled with student and synced roles.
+        // One of them is not enrolled for the course, and the other not in Sisu at all.
         expectGetEnrollmentsRequestToMoodle(
             MOODLE_COURSE_ID_1,
-            getEnrollmentsResponse((int) MOODLE_USER_NOT_ENROLLED, MOODLE_COURSE_ID_1,
-                mapperService.getStudentRoleId(), mapperService.getMoodiRoleId()));
+            getMoodleUserEnrollments((int) MOODLE_USER_NOT_ENROLLED, MOODLE_USERNAME_NOT_ENROLLED, MOODLE_COURSE_ID_1,
+                mapperService.getStudentRoleId(), mapperService.getMoodiRoleId()),
+            getMoodleUserEnrollments((int) MOODLE_USER_NOT_IN_STUDY_REGISTRY, MOODLE_USERNAME_NOT_IN_STUDY_REGISTRY, MOODLE_COURSE_ID_1,
+                mapperService.getStudentRoleId(), mapperService.getMoodiRoleId())
+        );
         setupMoodleGetCourseResponse(MOODLE_COURSE_ID_2);
         expectGetEnrollmentsRequestToMoodle(MOODLE_COURSE_ID_2);
 
@@ -108,9 +112,13 @@ public class FullSyncJobSisuTest extends AbstractMoodiIntegrationTest {
             new MoodleEnrollment(getMoodiRoleId(), MOODLE_USER_TEACH_ONE, MOODLE_COURSE_ID_1)
         );
 
-        // The existing student gets suspended and student role removed, because no longer enrolled in Sisu.
-        expectSuspendRequestToMoodle(new MoodleEnrollment(getMoodiRoleId(), MOODLE_USER_NOT_ENROLLED, MOODLE_COURSE_ID_1));
-        expectAssignRolesToMoodle(false, new MoodleEnrollment(getStudentRoleId(), MOODLE_USER_NOT_ENROLLED, MOODLE_COURSE_ID_1));
+        // The existing students gets suspended and student role removed, because no longer enrolled or found in Sisu.
+        expectSuspendRequestToMoodle(
+            new MoodleEnrollment(getMoodiRoleId(), MOODLE_USER_NOT_IN_STUDY_REGISTRY, MOODLE_COURSE_ID_1),
+            new MoodleEnrollment(getMoodiRoleId(), MOODLE_USER_NOT_ENROLLED, MOODLE_COURSE_ID_1));
+        expectAssignRolesToMoodle(false,
+            new MoodleEnrollment(getStudentRoleId(), MOODLE_USER_NOT_IN_STUDY_REGISTRY, MOODLE_COURSE_ID_1),
+            new MoodleEnrollment(getStudentRoleId(), MOODLE_USER_NOT_ENROLLED, MOODLE_COURSE_ID_1));
 
         // Course two student and teachers are enrolled.
         expectEnrollmentRequestToMoodle(

--- a/src/test/java/fi/helsinki/moodi/scheduled/FullSynchronizationJobTest.java
+++ b/src/test/java/fi/helsinki/moodi/scheduled/FullSynchronizationJobTest.java
@@ -121,7 +121,8 @@ public class FullSynchronizationJobTest extends AbstractSynchronizationJobTest {
 
         expectGetEnrollmentsRequestToMoodle(
             MOODLE_COURSE_ID,
-            getEnrollmentsResponse(STUDENT_USER_MOODLE_ID, MOODLE_COURSE_ID, mapperService.getTeacherRoleId(), mapperService.getMoodiRoleId()));
+            getEnrollmentsResponse(STUDENT_USER_MOODLE_ID, STUDENT_USERNAME + USERNAME_SUFFIX,
+                MOODLE_COURSE_ID, mapperService.getTeacherRoleId(), mapperService.getMoodiRoleId()));
 
         expectFindUsersRequestsToIAMAndMoodle();
 
@@ -141,7 +142,8 @@ public class FullSynchronizationJobTest extends AbstractSynchronizationJobTest {
 
         expectGetEnrollmentsRequestToMoodle(
             MOODLE_COURSE_ID,
-            getEnrollmentsResponse(STUDENT_USER_MOODLE_ID, MOODLE_COURSE_ID, mapperService.getStudentRoleId(), mapperService.getMoodiRoleId()));
+            getEnrollmentsResponse(STUDENT_USER_MOODLE_ID, STUDENT_USERNAME + USERNAME_SUFFIX,
+                MOODLE_COURSE_ID, mapperService.getStudentRoleId(), mapperService.getMoodiRoleId()));
 
         expectFindUsersRequestsToIAMAndMoodle();
 
@@ -165,7 +167,7 @@ public class FullSynchronizationJobTest extends AbstractSynchronizationJobTest {
         // ...but only has the sync role in Moodle.
         expectGetEnrollmentsRequestToMoodle(
             MOODLE_COURSE_ID,
-            getEnrollmentsResponse(STUDENT_USER_MOODLE_ID, MOODLE_COURSE_ID, mapperService.getMoodiRoleId()));
+            getEnrollmentsResponse(STUDENT_USER_MOODLE_ID, STUDENT_USERNAME + USERNAME_SUFFIX, MOODLE_COURSE_ID, mapperService.getMoodiRoleId()));
 
         expectFindUsersRequestsToIAMAndMoodle();
 
@@ -188,7 +190,8 @@ public class FullSynchronizationJobTest extends AbstractSynchronizationJobTest {
 
         expectGetEnrollmentsRequestToMoodle(
             MOODLE_COURSE_ID,
-            getEnrollmentsResponse(STUDENT_USER_MOODLE_ID, SOME_OTHER_MOODLE_COURSE_ID, mapperService.getMoodiRoleId()));
+            getEnrollmentsResponse(STUDENT_USER_MOODLE_ID, STUDENT_USERNAME + USERNAME_SUFFIX,
+                SOME_OTHER_MOODLE_COURSE_ID, mapperService.getMoodiRoleId()));
 
         expectFindUsersRequestsToIAMAndMoodle();
 
@@ -208,7 +211,8 @@ public class FullSynchronizationJobTest extends AbstractSynchronizationJobTest {
 
         expectGetEnrollmentsRequestToMoodle(
             MOODLE_COURSE_ID,
-            getEnrollmentsResponse(STUDENT_USER_MOODLE_ID, MOODLE_COURSE_ID, mapperService.getStudentRoleId(), mapperService.getMoodiRoleId()));
+            getEnrollmentsResponse(STUDENT_USER_MOODLE_ID, STUDENT_USERNAME + USERNAME_SUFFIX,
+                MOODLE_COURSE_ID, mapperService.getStudentRoleId(), mapperService.getMoodiRoleId()));
 
         expectFindStudentRequestToIAMAndMoodle(STUDENT_NUMBER, STUDENT_USERNAME, STUDENT_USER_MOODLE_ID);
         expectFindStudentRequestToIAMAndMoodle(STUDENT_NUMBER + "1", STUDENT_USERNAME + "1", STUDENT_USER_MOODLE_ID + 1);
@@ -265,7 +269,8 @@ public class FullSynchronizationJobTest extends AbstractSynchronizationJobTest {
 
         expectGetEnrollmentsRequestToMoodle(
             MOODLE_COURSE_ID,
-            getEnrollmentsResponse(STUDENT_USER_MOODLE_ID, MOODLE_COURSE_ID, mapperService.getStudentRoleId(), mapperService.getMoodiRoleId()));
+            getEnrollmentsResponse(STUDENT_USER_MOODLE_ID, STUDENT_USERNAME + USERNAME_SUFFIX,
+                MOODLE_COURSE_ID, mapperService.getStudentRoleId(), mapperService.getMoodiRoleId()));
 
         expectFindStudentRequestToIAMAndMoodle(STUDENT_NUMBER, STUDENT_USERNAME, STUDENT_USER_MOODLE_ID);
         expectFindStudentRequestToIAMAndMoodle(STUDENT_NUMBER + "1", STUDENT_USERNAME + "1", STUDENT_USER_MOODLE_ID + 1);


### PR DESCRIPTION
…misten tulisi poistua myös Moodlessa

- Moodle enrollments of a course are now also processed during sync, and if a Moodle user with the student and synced roles is not present for the course in the study registry, the user will be suspended in Moodle and the student role removed.
- Tweaked tests to accommodate the above.

Other
- Increased connect timeout due to sync problems on prod.
- Improved logging to facilitate diagnosing sync problems on prod.