### PR TITLE
https://jira.it.helsinki.fi/browse/MOODI-119 Päivitetään Oodi-ID:t Si…

### DIFF
--- a/src/main/java/fi/helsinki/moodi/config/WebConfig.java
+++ b/src/main/java/fi/helsinki/moodi/config/WebConfig.java
@@ -21,6 +21,7 @@ import fi.helsinki.moodi.interceptor.AccessLoggingInterceptor;
 import fi.helsinki.moodi.interceptor.AuthorizingInterceptor;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.config.SocketConfig;
+import org.apache.http.impl.NoConnectionReuseStrategy;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.client.HttpClients;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -60,9 +61,9 @@ public class WebConfig implements WebMvcConfigurer {
         SocketConfig socketConfig = SocketConfig.custom()
             .setSoTimeout(socketTimeout)
             .build();
-        HttpClientBuilder clientBuilder = HttpClients.custom()
+        return HttpClients.custom()
             .setDefaultRequestConfig(requestConfig)
-            .setDefaultSocketConfig(socketConfig);
-        return clientBuilder;
+            .setDefaultSocketConfig(socketConfig)
+            .setConnectionReuseStrategy(new NoConnectionReuseStrategy()); // Try to get rid of NoHttpResponseExceptions.
     }
 }

--- a/src/main/java/fi/helsinki/moodi/integration/studyregistry/StudyRegistryService.java
+++ b/src/main/java/fi/helsinki/moodi/integration/studyregistry/StudyRegistryService.java
@@ -17,69 +17,36 @@
 
 package fi.helsinki.moodi.integration.studyregistry;
 
-import fi.helsinki.moodi.integration.oodi.OodiClient;
 import fi.helsinki.moodi.integration.sisu.SisuClient;
 import fi.helsinki.moodi.integration.sisu.SisuCourseUnitRealisation;
 import fi.helsinki.moodi.integration.sisu.SisuPerson;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import java.util.List;
-import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
-import static java.util.stream.Collectors.partitioningBy;
 
 @Service
 public class StudyRegistryService {
-
-    private final OodiClient oodiClient;
+    public static final String SISU_OODI_COURSE_PREFIX = "hy-CUR-";
     private final SisuClient sisuClient;
 
     @Autowired
-    public StudyRegistryService(OodiClient oodiClient, SisuClient sisuClient) {
-        this.oodiClient = oodiClient;
+    public StudyRegistryService(SisuClient sisuClient) {
         this.sisuClient = sisuClient;
     }
 
     public Optional<StudyRegistryCourseUnitRealisation> getCourseUnitRealisation(final String realisationId) {
-        if (isOodiId(realisationId)) {
-            return oodiClient.getCourseUnitRealisation(realisationId).flatMap(cur -> Optional.of(cur.toStudyRegistryCourseUnitRealisation()));
+        SisuCourseUnitRealisation sisuCur = sisuClient.getCourseUnitRealisation(realisationId);
+        if (sisuCur != null) {
+            StudyRegistryCourseUnitRealisation cur = sisuCur.toStudyRegistryCourseUnitRealisation();
+            // Diverging from existing pattern here:
+            // Getting all teacher user names immediately, as opposed to getting them one by one in EnrollmentExecutor,
+            // because it is simpler and more efficient this way.
+            cur.teachers = SisuPerson.toStudyRegistryTeachers(sisuClient.getPersons(sisuCur.teacherSisuIds()));
+            return Optional.of(cur);
         } else {
-            SisuCourseUnitRealisation sisuCur = sisuClient.getCourseUnitRealisation(realisationId);
-            if (sisuCur != null) {
-                StudyRegistryCourseUnitRealisation cur = sisuCur.toStudyRegistryCourseUnitRealisation();
-                // Diverging from existing pattern here:
-                // Getting all teacher user names immediately, as opposed to getting them one by one in EnrollmentExecutor,
-                // because it is simpler and more efficient this way.
-                cur.teachers = SisuPerson.toStudyRegistryTeachers(sisuClient.getPersons(sisuCur.teacherSisuIds()));
-                return Optional.of(cur);
-            } else {
-                return Optional.empty();
-            }
+            return Optional.empty();
         }
-    }
-
-    public List<StudyRegistryCourseUnitRealisation> getCourseUnitRealisations(final List<String> realisationIds) {
-        Map<Boolean, List<String>> idsByIsOodiId = realisationIds.stream().collect(partitioningBy(StudyRegistryService::isOodiId));
-
-        List<SisuCourseUnitRealisation> sisuCurs = sisuClient.getCourseUnitRealisations(idsByIsOodiId.get(false));
-
-        List<String> uniquePersonIds = sisuCurs.stream().flatMap(cur -> cur.teacherSisuIds().stream()).distinct().collect(Collectors.toList());
-
-        Map<String, StudyRegistryTeacher> teachersById =
-            sisuClient.getPersons(uniquePersonIds)
-                .stream().collect(Collectors.toMap(p -> p.id, p -> p.toStudyRegistryTeacher()));
-
-        Stream<StudyRegistryCourseUnitRealisation> sisu = sisuCurs.stream()
-            .map(cur -> cur.toStudyRegistryCourseUnitRealisation(teachersById));
-
-        Stream<StudyRegistryCourseUnitRealisation> oodi =
-            idsByIsOodiId.get(true).stream().map(id -> getCourseUnitRealisation(id)).filter(o -> o.isPresent()).map(o -> o.get());
-
-        return Stream.concat(sisu, oodi).collect(Collectors.toList());
     }
 
     public static boolean isOodiId(final String realisationId) {

--- a/src/main/java/fi/helsinki/moodi/service/synchronize/enrich/SisuCourseEnricher.java
+++ b/src/main/java/fi/helsinki/moodi/service/synchronize/enrich/SisuCourseEnricher.java
@@ -17,8 +17,12 @@
 
 package fi.helsinki.moodi.service.synchronize.enrich;
 
+import fi.helsinki.moodi.integration.sisu.SisuClient;
+import fi.helsinki.moodi.integration.sisu.SisuCourseUnitRealisation;
+import fi.helsinki.moodi.integration.sisu.SisuPerson;
 import fi.helsinki.moodi.integration.studyregistry.StudyRegistryCourseUnitRealisation;
 import fi.helsinki.moodi.integration.studyregistry.StudyRegistryService;
+import fi.helsinki.moodi.integration.studyregistry.StudyRegistryTeacher;
 import fi.helsinki.moodi.service.course.Course;
 import fi.helsinki.moodi.service.synchronize.SynchronizationItem;
 import org.slf4j.Logger;
@@ -34,23 +38,40 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import static java.util.stream.Collectors.partitioningBy;
+
 @Component
 public class SisuCourseEnricher extends AbstractEnricher {
     private static final Logger logger = LoggerFactory.getLogger(SisuCourseEnricher.class);
-    private final StudyRegistryService studyRegistryService;
+    private final SisuClient sisuClient;
     private Map<String, StudyRegistryCourseUnitRealisation> prefetchedCursById = new HashMap<>();
 
     @Autowired
-    protected SisuCourseEnricher(StudyRegistryService studyRegistryService) {
+    protected SisuCourseEnricher(SisuClient sisuClient) {
         super(1);
-        this.studyRegistryService = studyRegistryService;
+        this.sisuClient = sisuClient;
     }
 
     public void prefetchCourses(List<String> curIds) {
-        List<String> uniqueSisuIds = new LinkedHashSet<String>(curIds).stream()
+        List<String> uniqueSisuIds = new LinkedHashSet<>(curIds).stream()
             .filter(id -> !StudyRegistryService.isOodiId(id)).collect(Collectors.toList());
-        prefetchedCursById = studyRegistryService.getCourseUnitRealisations(uniqueSisuIds).stream()
+        prefetchedCursById = getSisuCourseUnitRealisations(uniqueSisuIds).stream()
             .collect(Collectors.toMap(c -> c.realisationId, c -> c));
+    }
+
+    private List<StudyRegistryCourseUnitRealisation> getSisuCourseUnitRealisations(final List<String> realisationIds) {
+        Map<Boolean, List<String>> idsByIsOodiId = realisationIds.stream().collect(partitioningBy(StudyRegistryService::isOodiId));
+
+        List<SisuCourseUnitRealisation> sisuCurs = sisuClient.getCourseUnitRealisations(idsByIsOodiId.get(false));
+
+        List<String> uniquePersonIds = sisuCurs.stream().flatMap(cur -> cur.teacherSisuIds().stream()).distinct().collect(Collectors.toList());
+
+        Map<String, StudyRegistryTeacher> teachersById =
+            sisuClient.getPersons(uniquePersonIds)
+                .stream().collect(Collectors.toMap(p -> p.id, SisuPerson::toStudyRegistryTeacher));
+
+        return sisuCurs.stream()
+            .map(cur -> cur.toStudyRegistryCourseUnitRealisation(teachersById)).collect(Collectors.toList());
     }
 
     @Override

--- a/src/test/java/fi/helsinki/moodi/web/AbstractSuccessfulCreateCourseTest.java
+++ b/src/test/java/fi/helsinki/moodi/web/AbstractSuccessfulCreateCourseTest.java
@@ -20,69 +20,29 @@ package fi.helsinki.moodi.web;
 import com.google.common.collect.Lists;
 import fi.helsinki.moodi.integration.moodle.MoodleEnrollment;
 import fi.helsinki.moodi.test.AbstractMoodiIntegrationTest;
-import fi.helsinki.moodi.test.fixtures.Fixtures;
-import org.springframework.http.MediaType;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
-
-import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
 
 public abstract class AbstractSuccessfulCreateCourseTest extends AbstractMoodiIntegrationTest {
 
-    protected static final String OODI_COURSE_REALISATION_ID = "102374742";
     protected static final String SISU_COURSE_REALISATION_ID = "hy-CUR-123";
-
-    protected static final String STUDENT_NUMBER_NIINA = "010342729";
-    protected static final String STUDENT_NUMBER_JUKKA = "011119854";
-    protected static final String STUDENT_NUMBER_MAKE = "011524656";
-    protected static final String EMP_NUMBER_HRAOPE = "9110588";
-
-    protected static final String ESB_USERNAME_NIINA = "niina";
-    protected static final String ESB_USERNAME_JUKKA = "jukka";
-    protected static final String ESB_USERNAME_MAKE = "make";
-    protected static final String ESB_USERNAME_HRAOPE = "hraopettaja";
-
-    protected static final String EXPECTED_OODI_DESCRIPTION_TO_MOODLE = "Description+1+%28fi%29+Description+2+%28fi%29";
     protected static final String EXPECTED_SISU_DESCRIPTION_TO_MOODLE = "https%3A%2F%2Fcourses.helsinki.fi%2Ffi%2FOODI-FLOW%2F136394381";
 
-    protected void setUpMockServerResponsesForOodiCourse() {
-        setUpOodiResponse();
-        setupIAMResponses();
-        setUpMoodleResponses(OODI_COURSE_REALISATION_ID, EXPECTED_OODI_DESCRIPTION_TO_MOODLE, "oodi_");
-    }
-
     protected void expectEnrollmentsWithAddedMoodiRoles(List<MoodleEnrollment> moodleEnrollments) {
-        List<MoodleEnrollment> moodleEnrollmentsWithMoodiRoles = moodleEnrollments.stream()
-            .flatMap(enrollment -> Stream.of(enrollment, new MoodleEnrollment(getMoodiRoleId(), enrollment.moodleUserId, enrollment.moodleCourseId)))
-            .collect(Collectors.toList());
-
-        expectEnrollmentRequestToMoodle(moodleEnrollmentsWithMoodiRoles.toArray(new MoodleEnrollment[moodleEnrollmentsWithMoodiRoles.size()]));
+        expectEnrollmentRequestToMoodle(moodleEnrollments.stream()
+            .flatMap(enrollment -> Stream.of(enrollment,
+                new MoodleEnrollment(getMoodiRoleId(), enrollment.moodleUserId, enrollment.moodleCourseId))).toArray(MoodleEnrollment[]::new));
     }
 
-    protected void setUpMockServerResponsesWithWarningsForOodiCourse() {
-        setUpOodiResponse();
-        setupIAMResponses();
-
-        expectCreateCourseRequestToMoodle(OODI_COURSE_REALISATION_ID, "oodi_", EXPECTED_OODI_DESCRIPTION_TO_MOODLE, MOODLE_COURSE_ID);
-
-        expectGetUserRequestToMoodle(MOODLE_USERNAME_NIINA, MOODLE_USER_ID_NIINA);
-        expectGetUserRequestToMoodle(MOODLE_USERNAME_JUKKA, MOODLE_USER_ID_JUKKA);
-        expectGetUserRequestToMoodleUserNotFound(MOODLE_USERNAME_MAKE);
-        expectGetUserRequestToMoodle(MOODLE_USERNAME_HRAOPE, MOODLE_USER_HRAOPE);
-
-        expectEnrollmentsWithAddedMoodiRoles(Lists.newArrayList(
-            new MoodleEnrollment(getStudentRoleId(), MOODLE_USER_ID_NIINA, MOODLE_COURSE_ID),
-            new MoodleEnrollment(getStudentRoleId(), MOODLE_USER_ID_JUKKA, MOODLE_COURSE_ID),
-            new MoodleEnrollment(getTeacherRoleId(), MOODLE_USER_HRAOPE, MOODLE_COURSE_ID)
-            ));
-    }
-
-    protected void setUpMockServerResponsesForSisuCourse() {
+    protected void setUpMockServerResponsesForSisuCourse123(boolean allUsersFound) {
         setUpSisuResponsesFor123();
-        setUpMoodleResponses(SISU_COURSE_REALISATION_ID, EXPECTED_SISU_DESCRIPTION_TO_MOODLE, "sisu_");
+        setUpMoodleResponses(SISU_COURSE_REALISATION_ID, EXPECTED_SISU_DESCRIPTION_TO_MOODLE, "sisu_", allUsersFound);
+    }
+
+    protected void setUpSisuResponseCourse123NotFound() {
+        mockSisuServer.expectCourseUnitRealisationRequest(SISU_COURSE_REALISATION_ID, "/sisu/course-unit-realisation-not-found.json");
     }
 
     protected void setUpSisuResponsesFor123() {
@@ -90,32 +50,31 @@ public abstract class AbstractSuccessfulCreateCourseTest extends AbstractMoodiIn
         mockSisuServer.expectPersonsRequest(Arrays.asList("hy-hlo-4"), "/sisu/persons.json");
     }
 
-    private void setUpOodiResponse() {
-        expectGetCourseUnitRealisationRequestToOodi(
-            OODI_COURSE_REALISATION_ID,
-            withSuccess(Fixtures.asString("/oodi/course-realisation.json"), MediaType.APPLICATION_JSON));
-    }
-
-    private void setUpMoodleResponses(String curId, String description, String moodleCourseIdPrefix) {
+    private void setUpMoodleResponses(String curId, String description, String moodleCourseIdPrefix, boolean allUsersFound) {
         expectCreateCourseRequestToMoodle(curId, moodleCourseIdPrefix, description, MOODLE_COURSE_ID);
 
         expectGetUserRequestToMoodle(MOODLE_USERNAME_NIINA, MOODLE_USER_ID_NIINA);
         expectGetUserRequestToMoodle(MOODLE_USERNAME_JUKKA, MOODLE_USER_ID_JUKKA);
-        expectGetUserRequestToMoodle(MOODLE_USERNAME_MAKE, MOODLE_USER_ID_MAKE);
+        if (allUsersFound) {
+            expectGetUserRequestToMoodle(MOODLE_USERNAME_MAKE, MOODLE_USER_ID_MAKE);
+        } else {
+            expectGetUserRequestToMoodleUserNotFound(MOODLE_USERNAME_MAKE);
+        }
         expectGetUserRequestToMoodle(MOODLE_USERNAME_HRAOPE, MOODLE_USER_HRAOPE);
 
-        expectEnrollmentsWithAddedMoodiRoles(Lists.newArrayList(
-            new MoodleEnrollment(getStudentRoleId(), MOODLE_USER_ID_NIINA, MOODLE_COURSE_ID),
-            new MoodleEnrollment(getStudentRoleId(), MOODLE_USER_ID_JUKKA, MOODLE_COURSE_ID),
-            new MoodleEnrollment(getStudentRoleId(), MOODLE_USER_ID_MAKE, MOODLE_COURSE_ID),
-            new MoodleEnrollment(getTeacherRoleId(), MOODLE_USER_HRAOPE, MOODLE_COURSE_ID)
-        ));
-    }
-
-    private void setupIAMResponses() {
-        expectFindStudentRequestToIAM(STUDENT_NUMBER_NIINA, ESB_USERNAME_NIINA);
-        expectFindStudentRequestToIAM(STUDENT_NUMBER_JUKKA, ESB_USERNAME_JUKKA);
-        expectFindStudentRequestToIAM(STUDENT_NUMBER_MAKE, ESB_USERNAME_MAKE);
-        expectFindEmployeeRequestToIAM(EMP_NUMBER_HRAOPE, ESB_USERNAME_HRAOPE);
+        if (allUsersFound) {
+            expectEnrollmentsWithAddedMoodiRoles(Lists.newArrayList(
+                new MoodleEnrollment(getStudentRoleId(), MOODLE_USER_ID_NIINA, MOODLE_COURSE_ID),
+                new MoodleEnrollment(getStudentRoleId(), MOODLE_USER_ID_JUKKA, MOODLE_COURSE_ID),
+                new MoodleEnrollment(getStudentRoleId(), MOODLE_USER_ID_MAKE, MOODLE_COURSE_ID),
+                new MoodleEnrollment(getTeacherRoleId(), MOODLE_USER_HRAOPE, MOODLE_COURSE_ID)
+            ));
+        } else {
+            expectEnrollmentsWithAddedMoodiRoles(Lists.newArrayList(
+                new MoodleEnrollment(getStudentRoleId(), MOODLE_USER_ID_NIINA, MOODLE_COURSE_ID),
+                new MoodleEnrollment(getStudentRoleId(), MOODLE_USER_ID_JUKKA, MOODLE_COURSE_ID),
+                new MoodleEnrollment(getTeacherRoleId(), MOODLE_USER_HRAOPE, MOODLE_COURSE_ID)
+            ));
+        }
     }
 }

--- a/src/test/java/fi/helsinki/moodi/web/CreateCourseTest.java
+++ b/src/test/java/fi/helsinki/moodi/web/CreateCourseTest.java
@@ -17,33 +17,19 @@
 
 package fi.helsinki.moodi.web;
 
-import com.google.common.collect.Lists;
-import fi.helsinki.moodi.integration.moodle.MoodleEnrollment;
-import fi.helsinki.moodi.test.fixtures.Fixtures;
 import org.junit.Test;
-import org.springframework.http.MediaType;
 
 import static java.lang.Math.toIntExact;
-import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 public class CreateCourseTest extends AbstractSuccessfulCreateCourseTest {
 
-    private static String COURSE_NOT_FOUND_MESSAGE = "Study registry course not found with realisation id %s";
-
-    @Test
-    public void successfulCreateCourseReturnsCorrectResponse() throws Exception {
-        setUpMockServerResponsesForOodiCourse();
-
-        makeCreateCourseRequest(OODI_COURSE_REALISATION_ID)
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.data.moodleCourseId").value(toIntExact(MOODLE_COURSE_ID)));
-    }
+    private static String COURSE_NOT_FOUND_MESSAGE = "Study registry course not found with realisation id %s (%s)";
 
     @Test
     public void successfulCreateCourseBySisuIDReturnsCorrectResponse() throws Exception {
-        setUpMockServerResponsesForSisuCourse();
+        setUpMockServerResponsesForSisuCourse123(true);
 
         makeCreateCourseRequest(SISU_COURSE_REALISATION_ID)
             .andExpect(status().isOk())
@@ -51,50 +37,33 @@ public class CreateCourseTest extends AbstractSuccessfulCreateCourseTest {
     }
 
     @Test
-    public void thatImportFailsIfOodiReturnsNullForData() throws Exception {
-        testEmptyOodiResponse(OODI_NULL_DATA_RESPONSE);
+    public void successfulCreateCourseByOodiNativeIDUsesSisuAndReturnsCorrectResponse() throws Exception {
+        setUpMockServerResponsesForSisuCourse123(true);
+
+        makeCreateCourseRequest("123")
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.data.moodleCourseId").value(toIntExact(MOODLE_COURSE_ID)));
     }
 
     @Test
-    public void thatImportFailsIfOodiReturnsEmptyString() throws Exception {
-        testEmptyOodiResponse(EMPTY_RESPONSE);
-    }
+    public void thatImportFailsIfCourseNotFoundInSisu() throws Exception {
+        setUpSisuResponseCourse123NotFound();
 
-    @Test
-    public void thatAutomaticEnabledCourseEnrollmentsAreMadeCorrectly() throws Exception {
-        expectGetCourseUnitRealisationRequestToOodi(
-            OODI_COURSE_REALISATION_ID,
-            withSuccess(Fixtures.asString("/oodi/course-realisation-automatic-enabled.json"), MediaType.APPLICATION_JSON));
-
-        expectCreateCourseRequestToMoodle(OODI_COURSE_REALISATION_ID, "oodi_", EXPECTED_OODI_DESCRIPTION_TO_MOODLE, MOODLE_COURSE_ID);
-
-        expectFindStudentRequestToIAM(STUDENT_NUMBER_NIINA, ESB_USERNAME_NIINA);
-        expectFindStudentRequestToIAM(STUDENT_NUMBER_JUKKA, ESB_USERNAME_JUKKA);
-        expectFindEmployeeRequestToIAM(EMP_NUMBER_HRAOPE, ESB_USERNAME_HRAOPE);
-
-        expectGetUserRequestToMoodle(MOODLE_USERNAME_NIINA, MOODLE_USER_ID_NIINA);
-        expectGetUserRequestToMoodle(MOODLE_USERNAME_JUKKA, MOODLE_USER_ID_JUKKA);
-        expectGetUserRequestToMoodle(MOODLE_USERNAME_HRAOPE, MOODLE_USER_HRAOPE);
-
-        expectEnrollmentsWithAddedMoodiRoles(Lists.newArrayList(
-            new MoodleEnrollment(getStudentRoleId(), MOODLE_USER_ID_NIINA, MOODLE_COURSE_ID),
-            new MoodleEnrollment(getStudentRoleId(), MOODLE_USER_ID_JUKKA, MOODLE_COURSE_ID),
-            new MoodleEnrollment(getTeacherRoleId(), MOODLE_USER_HRAOPE, MOODLE_COURSE_ID)
-            ));
-
-        makeCreateCourseRequest(OODI_COURSE_REALISATION_ID)
-            .andExpect(status().isOk());
-    }
-
-    private void testEmptyOodiResponse(String response) throws Exception {
-        expectGetCourseUnitRealisationRequestToOodi(
-            OODI_COURSE_REALISATION_ID,
-            withSuccess(response, MediaType.APPLICATION_JSON));
-
-        makeCreateCourseRequest(OODI_COURSE_REALISATION_ID)
+        makeCreateCourseRequest(SISU_COURSE_REALISATION_ID)
             .andExpect(status().isNotFound())
             .andExpect(jsonPath("$.error")
-                .value(String.format(COURSE_NOT_FOUND_MESSAGE, OODI_COURSE_REALISATION_ID)));
+                .value(String.format(COURSE_NOT_FOUND_MESSAGE, SISU_COURSE_REALISATION_ID, SISU_COURSE_REALISATION_ID)));
+    }
+
+    @Test
+    public void thatImportFailsIfCourseNotFoundInSisuWithOptimeNativeID() throws Exception {
+        setUpSisuResponseCourse123NotFound();
+        String oodiCourseFromOptime = "123";
+
+        makeCreateCourseRequest(oodiCourseFromOptime)
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.error")
+                .value(String.format(COURSE_NOT_FOUND_MESSAGE, SISU_COURSE_REALISATION_ID, oodiCourseFromOptime)));
     }
 }
 

--- a/src/test/java/fi/helsinki/moodi/web/GetCourseAndEnrollmentStatusTest.java
+++ b/src/test/java/fi/helsinki/moodi/web/GetCourseAndEnrollmentStatusTest.java
@@ -30,15 +30,24 @@ public class GetCourseAndEnrollmentStatusTest extends AbstractSuccessfulCreateCo
 
     @Before
     public void setUp() {
-        setUpMockServerResponsesWithWarningsForOodiCourse();
+        setUpMockServerResponsesForSisuCourse123(true);
     }
 
     @Test
-    public void successfulCreateCourseReturnsCorrectResponse() throws Exception {
-        makeCreateCourseRequest(OODI_COURSE_REALISATION_ID);
+    public void successfulCreateCourseReturnsCorrectResponseAlsoWithOodiNativeId() throws Exception {
+        makeCreateCourseRequest(SISU_COURSE_REALISATION_ID);
 
         mockMvc.perform(
-            get("/api/v1/courses/" + OODI_COURSE_REALISATION_ID)
+            get("/api/v1/courses/" + SISU_COURSE_REALISATION_ID)
+                .contentType(MediaType.APPLICATION_JSON)
+                .header("client-id", "testclient")
+                .header("client-token", "xxx123"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.url").value(getMoodleBaseUrl() + "/course/view.php?id=988888"))
+            .andExpect(jsonPath("$.importStatus").value(COMPLETED.toString()));
+
+        mockMvc.perform(
+            get("/api/v1/courses/123")
                 .contentType(MediaType.APPLICATION_JSON)
                 .header("client-id", "testclient")
                 .header("client-token", "xxx123"))

--- a/src/test/java/fi/helsinki/moodi/web/GetCourseTest.java
+++ b/src/test/java/fi/helsinki/moodi/web/GetCourseTest.java
@@ -28,8 +28,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 public class GetCourseTest extends AbstractMoodiIntegrationTest {
 
-    private static long REALISATION_ID_FOUND = 12345;
-    private static long REALISATION_ID_NOT_FOUND = 54321;
+    private static String REALISATION_ID_FOUND = "12345";
+    private static String REALISATION_ID_NOT_FOUND = "54321";
     private static String NOT_FOUND_RESPONSE_ERROR = "Course with realisationId %s not found";
     private static String NOT_FOUND_STATUS_STRING = "not-found";
 

--- a/src/test/java/fi/helsinki/moodi/web/SuccessfulCreateCourseWithEnrollmentWarningsTest.java
+++ b/src/test/java/fi/helsinki/moodi/web/SuccessfulCreateCourseWithEnrollmentWarningsTest.java
@@ -25,17 +25,15 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 public class SuccessfulCreateCourseWithEnrollmentWarningsTest extends AbstractSuccessfulCreateCourseTest {
 
-    private static final String COURSE_REALISATION_ID = "102374742";
-
     @Before
     public void setUp() {
-        setUpMockServerResponsesWithWarningsForOodiCourse();
+        setUpMockServerResponsesForSisuCourse123(false);
     }
 
     @Test
     public void successfulCreateCourseReturnsCorrectResponse() throws Exception {
-        makeCreateCourseRequest(COURSE_REALISATION_ID)
+        makeCreateCourseRequest(SISU_COURSE_REALISATION_ID)
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.moodleCourseId").value(988888));
+                .andExpect(jsonPath("$.data.moodleCourseId").value(MOODLE_COURSE_ID));
     }
 }

--- a/src/test/resources/db/migration/common/V107.01__courses.sql
+++ b/src/test/resources/db/migration/common/V107.01__courses.sql
@@ -1,2 +1,2 @@
 insert into course(id, realisation_id, moodle_id, created, modified, import_status)
-values (nextval('course_id_seq'), 12345, 54321, now(), now(),'COMPLETED_FAILED');
+values (nextval('course_id_seq'), '12345', 54321, now(), now(),'COMPLETED_FAILED');

--- a/src/test/resources/fixtures/sisu/course-unit-realisation-not-found.json
+++ b/src/test/resources/fixtures/sisu/course-unit-realisation-not-found.json
@@ -1,0 +1,70 @@
+{
+  "errors": [
+    {
+      "message": "404: Not Found",
+      "locations": [
+        {
+          "line": 1,
+          "column": 3
+        }
+      ],
+      "path": [
+        "course_unit_realisation"
+      ],
+      "extensions": {
+        "code": "INTERNAL_SERVER_ERROR",
+        "response": {
+          "body": {
+            "cause": null,
+            "stackTrace": [],
+            "deeper": [],
+            "message": "CourseUnitRealisationStore#hy-CUR-foo",
+            "suppressed": [],
+            "localizedMessage": "CourseUnitRealisationStore#hy-CUR-foo"
+          },
+          "url": "http://localhost/kori/api/course-unit-realisations?id=hy-CUR-foo",
+          "status": 404,
+          "statusText": "Not Found"
+        },
+        "exception": {
+          "stacktrace": [
+            "Error: 404: Not Found",
+            "    at l.<anonymous> (/app/dist/index.js:1:4429)",
+            "    at Generator.next (<anonymous>)",
+            "    at /app/dist/index.js:1:2187",
+            "    at new Promise (<anonymous>)",
+            "    at i (/app/dist/index.js:1:1932)",
+            "    at l.errorFromResponse (/app/dist/index.js:1:4249)",
+            "    at l.<anonymous> (/app/dist/index.js:1:4146)",
+            "    at Generator.next (<anonymous>)",
+            "    at /app/dist/index.js:1:2187",
+            "    at new Promise (<anonymous>)"
+          ]
+        }
+      }
+    }
+  ],
+  "data": null,
+  "extensions": {
+    "tracing": {
+      "version": 1,
+      "startTime": "2021-02-19T15:55:08.916Z",
+      "endTime": "2021-02-19T15:55:08.925Z",
+      "duration": 9019287,
+      "execution": {
+        "resolvers": [
+          {
+            "path": [
+              "course_unit_realisation"
+            ],
+            "parentType": "Query",
+            "fieldName": "course_unit_realisation",
+            "returnType": "CourseUnitRealisation!",
+            "startOffset": 899717,
+            "duration": 8040281
+          }
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
…su-ID:ksi Moodin kannassa

- If course is requested with an Oodi ID and not found, try to fetch it from Sisu with a mechanically converted ID.
- If a course creation request is made with an Oodi ID, convert it mechanically into a Sisu ID. If the course is not found, log both the original and converted ID.
- Identify from Sisu errors the case when the requested object is not found.

Other:
- Try to get rid of NoHttpResponseExceptions by not reusing HTTP client connections.