### PR TITLE
https://jira.it.helsinki.fi/browse/MOODI-134 Muutetaan Moodi-Moodle-i…

### DIFF
--- a/src/itest/java/fi/helsinki/moodi/moodle/MoodleIntegrationSynchronizeCourseTest.java
+++ b/src/itest/java/fi/helsinki/moodi/moodle/MoodleIntegrationSynchronizeCourseTest.java
@@ -163,7 +163,7 @@ public class MoodleIntegrationSynchronizeCourseTest extends AbstractMoodleIntegr
     }
 
     @Test
-    public void testSyncRemovesRolesIfSosuDoesNotReturnEnrolledUsers() {
+    public void testSyncRemovesRolesIfSisuDoesNotReturnEnrolledUsers() {
         String sisuCourseId = getSisuCourseId();
 
         expectCourseRealisationWithUsers(sisuCourseId, singletonList(studentUser), singletonList(teacherUser));

--- a/src/test/resources/db/migration/common/V108.01__sequences_increment_50.sql
+++ b/src/test/resources/db/migration/common/V108.01__sequences_increment_50.sql
@@ -1,0 +1,2 @@
+alter sequence course_id_seq minvalue 0 increment by 50;
+alter sequence synchronization_job_run_id_seq minvalue 0 increment by 50;


### PR DESCRIPTION
…ntegraatiotestit käyttämään vain Sisu-kursseja

Fixed broken Moodi-Moodle integration tests. The problem was:
- Sequences in H2 had increment of 1, instead of 50. (In psql the increment is 50)
- @SequenceGenerator allocationSize default is 50.
- A test class starts up the App. Hibernate allocates 50 IDs and increments sequence by 1. The test inserts 11 SJR:s in the DB.
- Another test class starts up with different test properties, forcing a new App instance. The H2 in-memory DB retains it's content, but a new Hibernate emerges and reads the sequence value, and allocates 50 IDs starting from that. 11 of those IDs are already taken.
- An insert with a taken ID fails.
- If the two test classes were executed in reverse order (like on my Mac), the tests would pass, because the other test class only inserts one SJR, so no ID clash happens.
- The integration tests were passing previously, because AbstractMoodleIntegrationTest used to extend AbstractMoodiIntegrationTest which clears the DB between each test using flyway.clean();flyway.migrate()

Also fixed a typo in a test name.