### PR TITLE
https://jira.it.helsinki.fi/browse/MOODI-141 esbmt1.it.helsinki.fi aj…

### DIFF
--- a/src/main/java/fi/helsinki/moodi/config/IAMConfig.java
+++ b/src/main/java/fi/helsinki/moodi/config/IAMConfig.java
@@ -50,6 +50,9 @@ public class IAMConfig {
     @Value("${integration.iam.url:#{null}}")
     private String baseUrl;
 
+    @Value("${integration.iam.apiKey:#{null}}")
+    private String apiKey;
+
     @Value("${integration.iam.mock:false}")
     private boolean mockClientImplementation;
 
@@ -61,7 +64,7 @@ public class IAMConfig {
         if (mockClientImplementation) {
             return new IAMMockClient(getMockUsers());
         } else {
-            return new IAMRestClient(baseUrl, iamRestTemplate(objectMapper, clientBuilder));
+            return new IAMRestClient(baseUrl, apiKey, iamRestTemplate(objectMapper, clientBuilder));
         }
     }
 

--- a/src/main/java/fi/helsinki/moodi/integration/iam/IAMRestClient.java
+++ b/src/main/java/fi/helsinki/moodi/integration/iam/IAMRestClient.java
@@ -21,7 +21,10 @@ import fi.helsinki.moodi.exception.IntegrationConnectionException;
 import org.slf4j.Logger;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpMethod;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.ResourceAccessException;
 import org.springframework.web.client.RestTemplate;
 
@@ -35,10 +38,12 @@ public class IAMRestClient implements IAMClient {
     private static final Logger logger = getLogger(IAMRestClient.class);
 
     private final String baseUrl;
+    private String apiKey;
     private final RestTemplate restTemplate;
 
-    public IAMRestClient(String baseUrl, RestTemplate restTemplate) {
+    public IAMRestClient(String baseUrl, String apiKey, RestTemplate restTemplate) {
         this.baseUrl = baseUrl;
+        this.apiKey = apiKey;
         this.restTemplate = restTemplate;
     }
 
@@ -50,7 +55,7 @@ public class IAMRestClient implements IAMClient {
             List<IAMStudent> result = restTemplate.exchange(
                 String.format("%s/iam/findStudent/%s", baseUrl, studentNumber),
                 HttpMethod.GET,
-                null,
+                apiKeyHeaders(),
                 new ParameterizedTypeReference<List<IAMStudent>>() {})
                 .getBody();
 
@@ -75,7 +80,7 @@ public class IAMRestClient implements IAMClient {
             List<IAMEmployee> result = restTemplate.exchange(
                 String.format("%s/iam/findEmployee/%s", baseUrl, employeeNumber),
                 HttpMethod.GET,
-                null,
+                apiKeyHeaders(),
                 new ParameterizedTypeReference<List<IAMEmployee>>() {})
                 .getBody();
 
@@ -90,5 +95,11 @@ public class IAMRestClient implements IAMClient {
         } catch (ResourceAccessException e) {
             throw new IntegrationConnectionException("IAM connection failure", e);
         }
+    }
+
+    private HttpEntity apiKeyHeaders() {
+        MultiValueMap<String, String> headers = new LinkedMultiValueMap<String, String>();
+        headers.add("Apikey", apiKey);
+        return new HttpEntity(headers);
     }
 }

--- a/src/main/resources/config/application-prod.yml
+++ b/src/main/resources/config/application-prod.yml
@@ -14,7 +14,9 @@ integration:
   moodle:
     baseUrl: https://moodle.helsinki.fi
   oodi.url: https://esbmt1.it.helsinki.fi/secure/doo-oodi/v1/productiondb
-  iam.url: https://esbmt1.it.helsinki.fi
+  iam:
+    url: https://esb-api.it.helsinki.fi
+    apiKey: ${iamApiKey}
   sisu:
     baseUrl: https://gw.api.helsinki.fi/secure/sisu
     apiKey: ${apiGatewayApiKey}

--- a/src/test/java/fi/helsinki/moodi/integration/HttpClientTest.java
+++ b/src/test/java/fi/helsinki/moodi/integration/HttpClientTest.java
@@ -29,6 +29,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockserver.client.MockServerClient;
 import org.mockserver.junit.MockServerRule;
+import org.mockserver.model.MediaType;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
@@ -50,6 +51,7 @@ import static org.mockserver.model.HttpResponse.response;
         "integration.oodi.url=http://localhost:9876",
         "integration.moodle.baseUrl=http://localhost:9876",
         "integration.iam.url=http://localhost:9876",
+        "integration.iam.apiKey=abloy",
         "integration.sisu.baseUrl=http://localhost:9876",
         "httpClient.connectTimeout=100",
         "httpClient.socketTimeout=100"
@@ -91,6 +93,13 @@ public class HttpClientTest {
     @Test
     public void thatIAMClientDoesNotHang() {
         testTimeout(this::callIAM);
+    }
+
+    @Test
+    public void thatIAMClientPassesApiKey() {
+        mockServerClient.when(request().withHeader("Apikey", "abloy"))
+                .respond(response().withBody("[]").withContentType(MediaType.JSON_UTF_8));
+        iamClient.getStudentUserNameList("1");
     }
 
     private void testTimeout(Consumer<String> f) {


### PR DESCRIPTION
…etaan alas masterinvaihdon aikana

- Changed IAM URL from esbmt1 to esb-api.
- IAMRestClient now passes the configured api key in the HTTP header "Apikey".