### PR TITLE
MOODI-146 Kurssialueen shortname-generointi tuottaa tuplia

### DIFF
--- a/src/itest/java/fi/helsinki/moodi/moodle/AbstractMoodleIntegrationTest.java
+++ b/src/itest/java/fi/helsinki/moodi/moodle/AbstractMoodleIntegrationTest.java
@@ -65,7 +65,7 @@ import static org.springframework.test.web.client.response.MockRestResponseCreat
 @ActiveProfiles("test")
 @RunWith(SpringJUnit4ClassRunner.class)
 @SpringBootTest(
-    properties = { "server.port:0" },
+    properties = { "server.port:0", "test.MoodleCourseBuilder.overrideShortname:true" },
     classes = { Application.class, TestConfig.class })
 public abstract class AbstractMoodleIntegrationTest {
 

--- a/src/itest/java/fi/helsinki/moodi/moodle/MoodleIntegrationImportCourseTest.java
+++ b/src/itest/java/fi/helsinki/moodi/moodle/MoodleIntegrationImportCourseTest.java
@@ -62,7 +62,9 @@ public class MoodleIntegrationImportCourseTest extends AbstractMoodleIntegration
         assertThat(mfc.fullName).isEqualTo("Lapsuus ja yhteiskunta");
         assertThat(mfc.displayName).isEqualTo("Lapsuus ja yhteiskunta");
         assertThat(mfc.endDate).isGreaterThan(mfc.startDate);
-        assertThat(mfc.shortName).contains(sisuCourseId);
+        // The unique shortname suffix for integration tests is derived from the current time and
+        // will stay the same length until the year ~2055.
+        assertThat(mfc.shortName).startsWith("Lapsu-");
         assertThat(mfc.idNumber).isEqualTo("sisu_" + sisuCourseId);
         assertThat(mfc.lang).isEmpty();
         assertThat(mfc.summary).isEqualTo("https://courses.helsinki.fi/fi/OODI-FLOW/136394381");

--- a/src/main/java/fi/helsinki/moodi/service/course/Course.java
+++ b/src/main/java/fi/helsinki/moodi/service/course/Course.java
@@ -49,8 +49,7 @@ public class Course {
     public String realisationId;
 
     @Column(name = "moodle_id")
-    @NotNull
-    public long moodleId;
+    public Long moodleId;
 
     @Column(name = "created")
     @NotNull

--- a/src/main/java/fi/helsinki/moodi/service/course/CourseRepository.java
+++ b/src/main/java/fi/helsinki/moodi/service/course/CourseRepository.java
@@ -30,6 +30,7 @@ public interface CourseRepository extends JpaRepository<Course, Long> {
 
     List<Course> findByImportStatusInAndRemovedFalse(List<ImportStatus> importStatus);
 
-    List<Course> findByImportStatusInAndRealisationIdIn(List<ImportStatus> importStatuses, List<String> realisationIds);
+    List<Course> findByImportStatusInAndRemovedFalseAndMoodleIdNotNull(List<ImportStatus> importStatus);
 
+    List<Course> findByImportStatusInAndRealisationIdInAndMoodleIdNotNull(List<ImportStatus> importStatuses, List<String> realisationIds);
 }

--- a/src/main/java/fi/helsinki/moodi/service/synchronize/loader/FullSynchronizationCourseLoader.java
+++ b/src/main/java/fi/helsinki/moodi/service/synchronize/loader/FullSynchronizationCourseLoader.java
@@ -40,7 +40,7 @@ public class FullSynchronizationCourseLoader implements CourseLoader {
 
     @Override
     public List<Course> load() {
-        return courseService.findAllCompleted();
+        return courseService.findAllCompletedWithMoodleId();
     }
 
     @Override

--- a/src/main/java/fi/helsinki/moodi/service/synchronize/loader/IncrementalSynchronizationCourseLoader.java
+++ b/src/main/java/fi/helsinki/moodi/service/synchronize/loader/IncrementalSynchronizationCourseLoader.java
@@ -38,6 +38,7 @@ import static org.slf4j.LoggerFactory.getLogger;
 
 /**
  * Implementation for incremental synchronization.
+ * DO NOT USE, has not been modified to support Sisu.
  */
 @Component
 public class IncrementalSynchronizationCourseLoader implements CourseLoader {
@@ -77,7 +78,7 @@ public class IncrementalSynchronizationCourseLoader implements CourseLoader {
                 .map(o -> "" + o.courseUnitRealisationId)
                 .collect(Collectors.toList());
 
-        return courseService.findCompletedByRealisationIds(realisationIds);
+        return courseService.findCompletedWithMoodleIdByRealisationIds(realisationIds);
     }
 
     @Override

--- a/src/main/java/fi/helsinki/moodi/web/CourseController.java
+++ b/src/main/java/fi/helsinki/moodi/web/CourseController.java
@@ -60,7 +60,7 @@ public class CourseController {
     public ResponseEntity<CourseDto> getCourse(
         @PathVariable("realisationId") String realisationId) {
 
-        return response(importingService.getCourse(realisationId));
+        return response(importingService.getImportedCourse(realisationId));
     }
 
     private <D, E> ResponseEntity<Result<D, E>> response(Result<D, E> result) {

--- a/src/main/resources/config/application.yml
+++ b/src/main/resources/config/application.yml
@@ -18,7 +18,7 @@ httpClient:
   # Defines the socket timeout (SO_TIMEOUT) in milliseconds,
   # which is the timeout for waiting for data  or, put differently,
   # a maximum period inactivity between two consecutive data packets).
-  socketTimeout: 30000
+  socketTimeout: 60000
 
 oodi.enrollmentApprovedStatusCodes: 2, 3, 7, 8
 

--- a/src/main/resources/db/migration/common/V011.00__allow_null_moodle_id.sql
+++ b/src/main/resources/db/migration/common/V011.00__allow_null_moodle_id.sql
@@ -1,0 +1,1 @@
+ALTER TABLE course ALTER COLUMN moodle_id DROP NOT NULL;

--- a/src/test/java/fi/helsinki/moodi/scheduled/FullSyncJobSisuTest.java
+++ b/src/test/java/fi/helsinki/moodi/scheduled/FullSyncJobSisuTest.java
@@ -138,7 +138,7 @@ public class FullSyncJobSisuTest extends AbstractMoodiIntegrationTest {
 
     // Initialize course repository with test courses.
     private void coursesInDb(Course...courses) {
-        when(courseRepository.findByImportStatusInAndRemovedFalse(anyList())).thenReturn(Arrays.asList(courses));
+        when(courseRepository.findByImportStatusInAndRemovedFalseAndMoodleIdNotNull(anyList())).thenReturn(Arrays.asList(courses));
     }
 
     private Course getCourse(String id, long moodleId) {

--- a/src/test/java/fi/helsinki/moodi/test/AbstractMoodiIntegrationTest.java
+++ b/src/test/java/fi/helsinki/moodi/test/AbstractMoodiIntegrationTest.java
@@ -25,6 +25,7 @@ import fi.helsinki.moodi.integration.moodle.MoodleCourseData;
 import fi.helsinki.moodi.integration.moodle.MoodleEnrollment;
 import fi.helsinki.moodi.integration.moodle.MoodleRole;
 import fi.helsinki.moodi.integration.moodle.MoodleUserEnrollments;
+import fi.helsinki.moodi.service.course.CourseRepository;
 import fi.helsinki.moodi.service.importing.ImportCourseRequest;
 import fi.helsinki.moodi.service.synchronize.enrich.SisuCourseEnricher;
 import fi.helsinki.moodi.service.util.MapperService;
@@ -60,6 +61,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
+import static org.hamcrest.Matchers.*;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.*;
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -148,6 +150,9 @@ public abstract class AbstractMoodiIntegrationTest {
 
     @Autowired
     private CacheManager cacheManager;
+
+    @Autowired
+    private CourseRepository courseRepository;
 
     protected MockMvc mockMvc;
 
@@ -386,13 +391,16 @@ public abstract class AbstractMoodiIntegrationTest {
             .andExpect(method(HttpMethod.POST))
             .andExpect(header("Content-Type", "application/x-www-form-urlencoded"))
             .andExpect(content().string(
-                "wstoken=xxxx1234&wsfunction=core_course_create_courses&moodlewsrestformat=json&courses%5B0%5D%5Bidnumber%5D="
-                    + moodleCourseIdPrefix + realisationId +
-                "&courses%5B0%5D%5Bfullname%5D=Lapsuus+ja+yhteiskunta&courses%5B0%5D%5Bshortname%5D=Lapsuus++" + realisationId +
-                "&courses%5B0%5D%5Bcategoryid%5D=" + categoryId +
-                "&courses%5B0%5D%5Bsummary%5D=" + description + "&courses%5B0%5D%5Bvisible%5D=0" +
-                "&courses%5B0%5D%5Bstartdate%5D=1564952400&courses%5B0%5D%5Benddate%5D=1575496800" + // End date plus one month
-                "&courses%5B0%5D%5Bcourseformatoptions%5D%5B0%5D%5Bname%5D=numsections&courses%5B0%5D%5Bcourseformatoptions%5D%5B0%5D%5Bvalue%5D=7"))
+                allOf(
+                    startsWith(
+                        "wstoken=xxxx1234&wsfunction=core_course_create_courses&moodlewsrestformat=json&courses%5B0%5D%5Bidnumber%5D="
+                            + moodleCourseIdPrefix + realisationId +
+                            "&courses%5B0%5D%5Bfullname%5D=Lapsuus+ja+yhteiskunta&courses%5B0%5D%5Bshortname%5D=Lapsuus+ja"),
+                    // The actual short name unique suffix is too difficult to check here, so we leave it out.
+                    endsWith("&courses%5B0%5D%5Bcategoryid%5D=" + categoryId +
+                        "&courses%5B0%5D%5Bsummary%5D=" + description + "&courses%5B0%5D%5Bvisible%5D=0" +
+                        "&courses%5B0%5D%5Bstartdate%5D=1564952400&courses%5B0%5D%5Benddate%5D=1575496800" + // End date plus one month
+                        "&courses%5B0%5D%5Bcourseformatoptions%5D%5B0%5D%5Bname%5D=numsections&courses%5B0%5D%5Bcourseformatoptions%5D%5B0%5D%5Bvalue%5D=7"))))
             .andRespond(withSuccess("[{\"id\":\"" + moodleCourseIdToReturn + "\", \"shortname\":\"shortie\"}]", MediaType.APPLICATION_JSON));
     }
 

--- a/src/test/java/fi/helsinki/moodi/test/AbstractMoodiIntegrationTest.java
+++ b/src/test/java/fi/helsinki/moodi/test/AbstractMoodiIntegrationTest.java
@@ -400,7 +400,8 @@ public abstract class AbstractMoodiIntegrationTest {
                     endsWith("&courses%5B0%5D%5Bcategoryid%5D=" + categoryId +
                         "&courses%5B0%5D%5Bsummary%5D=" + description + "&courses%5B0%5D%5Bvisible%5D=0" +
                         "&courses%5B0%5D%5Bstartdate%5D=1564952400&courses%5B0%5D%5Benddate%5D=1575496800" + // End date plus one month
-                        "&courses%5B0%5D%5Bcourseformatoptions%5D%5B0%5D%5Bname%5D=numsections&courses%5B0%5D%5Bcourseformatoptions%5D%5B0%5D%5Bvalue%5D=7"))))
+                        "&courses%5B0%5D%5Bcourseformatoptions%5D%5B0%5D%5B" +
+                        "name%5D=numsections&courses%5B0%5D%5Bcourseformatoptions%5D%5B0%5D%5Bvalue%5D=7"))))
             .andRespond(withSuccess("[{\"id\":\"" + moodleCourseIdToReturn + "\", \"shortname\":\"shortie\"}]", MediaType.APPLICATION_JSON));
     }
 

--- a/src/test/java/fi/helsinki/moodi/web/AbstractSuccessfulCreateCourseTest.java
+++ b/src/test/java/fi/helsinki/moodi/web/AbstractSuccessfulCreateCourseTest.java
@@ -53,7 +53,7 @@ public abstract class AbstractSuccessfulCreateCourseTest extends AbstractMoodiIn
         mockSisuGraphQLServer.expectPersonsRequest(Arrays.asList("hy-hlo-4"), "/sisu/persons.json");
     }
 
-    private void setUpMoodleResponses(String curId, String description, String moodleCourseIdPrefix, boolean allUsersFound, String categoryId) {
+    protected void setUpMoodleResponses(String curId, String description, String moodleCourseIdPrefix, boolean allUsersFound, String categoryId) {
         expectCreateCourseRequestToMoodle(curId, moodleCourseIdPrefix, description, MOODLE_COURSE_ID, categoryId);
 
         expectGetUserRequestToMoodle(MOODLE_USERNAME_NIINA, MOODLE_USER_ID_NIINA);

--- a/src/test/java/fi/helsinki/moodi/web/CreateCourseTest.java
+++ b/src/test/java/fi/helsinki/moodi/web/CreateCourseTest.java
@@ -17,13 +17,25 @@
 
 package fi.helsinki.moodi.web;
 
+import fi.helsinki.moodi.exception.CourseNotFoundException;
+import fi.helsinki.moodi.service.importing.ImportingService;
 import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpMethod;
 
 import static java.lang.Math.toIntExact;
+import static org.hamcrest.Matchers.startsWith;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.*;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withServerError;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 public class CreateCourseTest extends AbstractSuccessfulCreateCourseTest {
+
+    @Autowired
+    private ImportingService importingService;
 
     private static String COURSE_NOT_FOUND_MESSAGE = "Study registry course not found with realisation id %s (%s)";
 
@@ -64,6 +76,43 @@ public class CreateCourseTest extends AbstractSuccessfulCreateCourseTest {
             .andExpect(status().isNotFound())
             .andExpect(jsonPath("$.error")
                 .value(String.format(COURSE_NOT_FOUND_MESSAGE, SISU_COURSE_REALISATION_ID, oodiCourseFromOptime)));
+    }
+
+    @Test
+    public void thatIfFirstImportFailsTheSecondImportCanSucceed() throws Exception {
+        // Set up first try to get a server error from Moodle.
+        setUpSisuResponsesFor123();
+        expectSisuOrganisationExportRequest();
+
+        moodleMockServer.expect(requestTo(getMoodleRestUrl()))
+            .andExpect(method(HttpMethod.POST))
+            .andExpect(content().string(startsWith(
+                "wstoken=xxxx1234&wsfunction=core_course_create_courses")))
+            .andExpect(header("Content-Type", "application/x-www-form-urlencoded"))
+            .andRespond(withServerError());
+
+        // Set up second try to succeed. Sisu organisation call is not made, as it is cached.
+        setUpSisuResponsesFor123();
+        setUpMoodleResponses(SISU_COURSE_REALISATION_ID, EXPECTED_SISU_DESCRIPTION_TO_MOODLE, "sisu_", true, "9");
+
+        // First try.
+        makeCreateCourseRequest(SISU_COURSE_REALISATION_ID)
+            // Why return client error when Moodle is broken? I don't know, but not touching that right now.
+            .andExpect(status().is4xxClientError());
+
+        try {
+            importingService.getImportedCourse(SISU_COURSE_REALISATION_ID);
+            fail("Getting a course not in Moodle should have failed.");
+        } catch (CourseNotFoundException e) {
+            // Good.
+        }
+
+        // Second try.
+        makeCreateCourseRequest(SISU_COURSE_REALISATION_ID)
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.data.moodleCourseId").value(toIntExact(MOODLE_COURSE_ID)));
+
+        assertEquals("COMPLETED", importingService.getImportedCourse(SISU_COURSE_REALISATION_ID).importStatus);
     }
 }
 


### PR DESCRIPTION
- Now generating Moodle course shortname from the course name plus a unique suffix generated from the Moodi course DB ID represented in base 36.
- Shortname length is restricted to 16 and contains only ASCII characters.
- Course now gets inserted into the DB before sending it to Moodle, so the moodle_id column needs to allow nulls.
- If, during course import, the Moodle create course call fails, the Moodi get course API call still returns "not found" to the caller, because the course created in the DB does not have a moodle_id.
- Sync jobs now fetch only courses with moodle_id for processing.
- Integration tests need to override the way the shortname is generated, since the DB for them is not persistent and also collisions with DEV env would occur.
- Increased socket timeout, as there were some timeouts in the production log related to adding enrollments when there are lots of them.