### PR TITLE
Moodi 147 add creator as teacher

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,14 +40,13 @@ when new features are added.
 This is normally done in Jenkins, but if you want to test something locally, you need to go through 
 an ssh tunnel via moodi-dev, because the Moodle API has an IP restriction in place.
 
-Into /etc/hosts: 
-```
-127.0.0.1       moodi-2-moodle-20.student.helsinki.fi 
-```
-
 Open an ssh tunnel to call the Moodle API:
 ```
 ssh moodi-dev -L 1444:moodi-2-moodle-20.student.helsinki.fi:443
+```
+Into /etc/hosts:
+```
+127.0.0.1       moodi-2-moodle-20.student.helsinki.fi 
 ```
 
 Then run the tests

--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ when new features are added.
 ```
 
 ### Running Moodi-Moodle integration tests
-This is normally done in Jenkins, but if you want to test something locally, you need to go via an ssh tunnel.
+This is normally done in Jenkins, but if you want to test something locally, you need to go through 
+an ssh tunnel via moodi-dev, because the Moodle API has an IP restriction in place.
 
 Into /etc/hosts: 
 ```

--- a/src/itest/java/fi/helsinki/moodi/moodle/MoodleIntegrationImportCourseTest.java
+++ b/src/itest/java/fi/helsinki/moodi/moodle/MoodleIntegrationImportCourseTest.java
@@ -27,32 +27,27 @@ import java.util.List;
 import static com.google.common.collect.Lists.newArrayList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 public class MoodleIntegrationImportCourseTest extends AbstractMoodleIntegrationTest {
     @Test
     public void testMoodleIntegrationWhenImportingCourse() {
         String sisuCourseId = getSisuCourseId();
 
+        expectCreator(creatorUser);
+
         expectCourseRealisationsWithUsers(
             sisuCourseId,
             newArrayList(studentUser, studentUserNotInMoodle),
             newArrayList(teacherUser));
 
-        long moodleCourseId = importCourse(sisuCourseId);
+        long moodleCourseId = importCourse(sisuCourseId, creatorUser.personId);
 
         List<MoodleUserEnrollments> moodleUserEnrollmentsList = moodleClient.getEnrolledUsers(moodleCourseId);
-        assertEquals(2, moodleUserEnrollmentsList.size());
+        assertEquals(3, moodleUserEnrollmentsList.size());
 
-        MoodleUserEnrollments studentEnrollment = findEnrollmentsByUsername(moodleUserEnrollmentsList, STUDENT_USERNAME);
-        assertEquals(2, studentEnrollment.roles.size());
-        assertTrue(studentEnrollment.hasRole(mapperService.getMoodiRoleId()));
-        assertTrue(studentEnrollment.hasRole(mapperService.getStudentRoleId()));
-
-        MoodleUserEnrollments teacherEnrollment = findEnrollmentsByUsername(moodleUserEnrollmentsList, TEACHER_USERNAME);
-        assertEquals(2, teacherEnrollment.roles.size());
-        assertTrue(teacherEnrollment.hasRole(mapperService.getMoodiRoleId()));
-        assertTrue(teacherEnrollment.hasRole(mapperService.getTeacherRoleId()));
+        assertStudentEnrollment(STUDENT_USERNAME, moodleUserEnrollmentsList);
+        assertTeacherEnrollment(TEACHER_USERNAME, moodleUserEnrollmentsList);
+        assertTeacherEnrollment(CREATOR_USERNAME, moodleUserEnrollmentsList);
 
         List<MoodleFullCourse> moodleCourses = moodleClient.getCourses(Arrays.asList(moodleCourseId));
 

--- a/src/itest/java/fi/helsinki/moodi/moodle/MoodleIntegrationSynchronizeCourseTest.java
+++ b/src/itest/java/fi/helsinki/moodi/moodle/MoodleIntegrationSynchronizeCourseTest.java
@@ -35,18 +35,20 @@ public class MoodleIntegrationSynchronizeCourseTest extends AbstractMoodleIntegr
         String sisuCourseId = getSisuCourseId();
 
         expectCourseRealisationsWithUsers(sisuCourseId, singletonList(studentUser), singletonList(teacherUser));
+        expectCreator(creatorUser);
 
-        long moodleCourseId = importCourse(sisuCourseId);
+        long moodleCourseId = importCourse(sisuCourseId, creatorUser.personId);
 
         resetAndExpectCourseRealisationsWithUsers(sisuCourseId, singletonList(studentUser), singletonList(teacherUser));
         synchronizationService.synchronize(SynchronizationType.FULL);
 
         List<MoodleUserEnrollments> moodleUserEnrollmentsList = moodleClient.getEnrolledUsers(moodleCourseId);
 
-        assertEquals(2, moodleUserEnrollmentsList.size());
+        assertEquals(3, moodleUserEnrollmentsList.size());
 
         assertStudentEnrollment(STUDENT_USERNAME, moodleUserEnrollmentsList);
         assertTeacherEnrollment(TEACHER_USERNAME, moodleUserEnrollmentsList);
+        assertTeacherEnrollment(CREATOR_USERNAME, moodleUserEnrollmentsList);
     }
 
     @Test

--- a/src/main/java/fi/helsinki/moodi/integration/sisu/SisuClient.java
+++ b/src/main/java/fi/helsinki/moodi/integration/sisu/SisuClient.java
@@ -79,7 +79,9 @@ public class SisuClient {
         for (List batchIds : splitToBatches(ids)) {
             Arguments idArgument = new Arguments("private_persons", new Argument<>("ids", batchIds));
             SisuPerson.SisuPersonWrapper result = queryWithArguments(SisuPerson.SisuPersonWrapper.class, idArgument);
-            ret.addAll(result.private_persons);
+            if (result != null) {
+                ret.addAll(result.private_persons);
+            }
         }
         return ret;
     }
@@ -187,6 +189,7 @@ public class SisuClient {
     private boolean isOne404(GraphQLResponseEntity responseEntity) {
         return responseEntity.getErrors() != null &&
             responseEntity.getErrors().length == 1 &&
-            "404: Not Found".equals(responseEntity.getErrors()[0].getMessage());
+            responseEntity.getErrors()[0].getMessage() != null &&
+            responseEntity.getErrors()[0].getMessage().contains("404: Not Found");
     }
 }

--- a/src/main/java/fi/helsinki/moodi/service/course/Course.java
+++ b/src/main/java/fi/helsinki/moodi/service/course/Course.java
@@ -48,6 +48,9 @@ public class Course {
     @NotNull
     public String realisationId;
 
+    @Column(name = "creator_username")
+    public String creatorUsername;
+
     @Column(name = "moodle_id")
     public Long moodleId;
 

--- a/src/main/java/fi/helsinki/moodi/service/course/CourseService.java
+++ b/src/main/java/fi/helsinki/moodi/service/course/CourseService.java
@@ -58,12 +58,13 @@ public class CourseService {
         return courseRepository.findByImportStatusInAndRemovedFalseAndMoodleIdNotNull(newArrayList(COMPLETED, COMPLETED_FAILED));
     }
 
-    public Course createCourse(final String realisationId, final Long moodleCourseId) {
+    public Course createCourse(final String realisationId, final Long moodleCourseId, final String creatorUsername) {
         final Course course = new Course();
         course.created = timeService.getCurrentUTCDateTime();
         course.moodleId = moodleCourseId;
         course.realisationId = realisationId;
         course.importStatus = IN_PROGRESS;
+        course.creatorUsername = creatorUsername;
         return saveCourse(course);
     }
 

--- a/src/main/java/fi/helsinki/moodi/service/importing/Enrollment.java
+++ b/src/main/java/fi/helsinki/moodi/service/importing/Enrollment.java
@@ -47,10 +47,10 @@ public final class Enrollment {
     public static Enrollment forTeacher(final String employeeNumber, final String userName) {
         return new Enrollment(ROLE_TEACHER, Optional.ofNullable(employeeNumber), Optional.empty(), userName, Optional.empty(), true);
     }
+
     public static Enrollment forCreator(final String creatorUsername) {
         return new Enrollment(ROLE_TEACHER, Optional.empty(), Optional.empty(), creatorUsername, Optional.empty(), true);
     }
-
 
     private Enrollment(String role, Optional<String> employeeNumber, Optional<String> studentNumber, String userName,
                        Optional<Long> moodleId, boolean approved) {

--- a/src/main/java/fi/helsinki/moodi/service/importing/Enrollment.java
+++ b/src/main/java/fi/helsinki/moodi/service/importing/Enrollment.java
@@ -47,6 +47,10 @@ public final class Enrollment {
     public static Enrollment forTeacher(final String employeeNumber, final String userName) {
         return new Enrollment(ROLE_TEACHER, Optional.ofNullable(employeeNumber), Optional.empty(), userName, Optional.empty(), true);
     }
+    public static Enrollment forCreator(final String creatorUsername) {
+        return new Enrollment(ROLE_TEACHER, Optional.empty(), Optional.empty(), creatorUsername, Optional.empty(), true);
+    }
+
 
     private Enrollment(String role, Optional<String> employeeNumber, Optional<String> studentNumber, String userName,
                        Optional<Long> moodleId, boolean approved) {

--- a/src/main/java/fi/helsinki/moodi/service/importing/EnrollmentExecutor.java
+++ b/src/main/java/fi/helsinki/moodi/service/importing/EnrollmentExecutor.java
@@ -85,7 +85,7 @@ public class EnrollmentExecutor {
 
             final List<EnrollmentWarning> enrollmentWarnings = newArrayList();
 
-            final List<Enrollment> enrollments = createEnrollments(courseUnitRealisation);
+            final List<Enrollment> enrollments = createEnrollments(courseUnitRealisation, course.creatorUsername);
 
             final List<Enrollment> approvedEnrollments = filterApprovedEnrollments(enrollments, enrollmentWarnings);
             final List<Enrollment> enrollmentsWithUsernames = enrichEnrollmentsWithUsernames(approvedEnrollments);
@@ -133,7 +133,7 @@ public class EnrollmentExecutor {
         return enrollment;
     }
 
-    private List<Enrollment> createEnrollments(final StudyRegistryCourseUnitRealisation cur) {
+    private List<Enrollment> createEnrollments(final StudyRegistryCourseUnitRealisation cur, final String creatorUsername) {
         final List<Enrollment> enrollments = newArrayList();
 
         enrollments.addAll(cur.students.stream()
@@ -146,6 +146,10 @@ public class EnrollmentExecutor {
         enrollments.addAll(cur.teachers.stream()
             .map(s -> Enrollment.forTeacher(s.employeeNumber, s.userName))
             .collect(toList()));
+
+        if (creatorUsername != null) {
+            enrollments.add(Enrollment.forCreator(creatorUsername));
+        }
 
         return enrollments;
     }

--- a/src/main/java/fi/helsinki/moodi/service/importing/ImportCourseRequest.java
+++ b/src/main/java/fi/helsinki/moodi/service/importing/ImportCourseRequest.java
@@ -34,8 +34,12 @@ public final class ImportCourseRequest {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
         ImportCourseRequest that = (ImportCourseRequest) o;
         return Objects.equals(realisationId, that.realisationId) && Objects.equals(creatorSisuId, that.creatorSisuId);
     }

--- a/src/main/java/fi/helsinki/moodi/service/importing/ImportCourseRequest.java
+++ b/src/main/java/fi/helsinki/moodi/service/importing/ImportCourseRequest.java
@@ -24,6 +24,8 @@ public final class ImportCourseRequest {
     @NotNull
     public String realisationId;
 
+    public String creatorSisuId;
+
     public ImportCourseRequest() {}
 
     public ImportCourseRequest(String i) {
@@ -32,18 +34,14 @@ public final class ImportCourseRequest {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
         ImportCourseRequest that = (ImportCourseRequest) o;
-        return Objects.equals(realisationId, that.realisationId);
+        return Objects.equals(realisationId, that.realisationId) && Objects.equals(creatorSisuId, that.creatorSisuId);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(realisationId);
+        return Objects.hash(realisationId, creatorSisuId);
     }
 }

--- a/src/main/java/fi/helsinki/moodi/service/importing/ImportingService.java
+++ b/src/main/java/fi/helsinki/moodi/service/importing/ImportingService.java
@@ -52,7 +52,6 @@ public class ImportingService {
     private final LoggingService loggingService;
     private final SisuClient sisuClient;
 
-
     @Autowired
     public ImportingService(
         MoodleService moodleService,

--- a/src/main/java/fi/helsinki/moodi/service/importing/ImportingService.java
+++ b/src/main/java/fi/helsinki/moodi/service/importing/ImportingService.java
@@ -22,8 +22,8 @@ import fi.helsinki.moodi.exception.CourseNotFoundException;
 import fi.helsinki.moodi.integration.moodle.MoodleCourse;
 import fi.helsinki.moodi.integration.moodle.MoodleService;
 import fi.helsinki.moodi.integration.sisu.SisuClient;
-import fi.helsinki.moodi.integration.studyregistry.StudyRegistryService;
 import fi.helsinki.moodi.integration.studyregistry.StudyRegistryCourseUnitRealisation;
+import fi.helsinki.moodi.integration.studyregistry.StudyRegistryService;
 import fi.helsinki.moodi.service.Result;
 import fi.helsinki.moodi.service.converter.CourseConverter;
 import fi.helsinki.moodi.service.course.Course;
@@ -33,7 +33,7 @@ import fi.helsinki.moodi.service.log.LoggingService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.Optional;
 
 import static fi.helsinki.moodi.exception.NotFoundException.notFoundException;
@@ -114,7 +114,7 @@ public class ImportingService {
 
     private String getUserNameOrThrow(String creatorSisuId) {
         return creatorSisuId != null ?
-            sisuClient.getPersons(Arrays.asList(creatorSisuId)).stream()
+            sisuClient.getPersons(Collections.singletonList(creatorSisuId)).stream()
                 .findFirst()
                 .orElseThrow(notFoundException(String.format("Sisu person not found with id %s", creatorSisuId)))
                 .eduPersonPrincipalName :

--- a/src/main/java/fi/helsinki/moodi/service/synchronize/enrich/SisuCourseEnricher.java
+++ b/src/main/java/fi/helsinki/moodi/service/synchronize/enrich/SisuCourseEnricher.java
@@ -65,10 +65,6 @@ public class SisuCourseEnricher extends AbstractEnricher {
             return item.completeEnrichmentPhase(
                 EnrichmentStatus.ERROR,
                 String.format("Course not found from Sisu with id %s", course.realisationId));
-        } else if (!cur.published) {
-            return item.completeEnrichmentPhase(
-                EnrichmentStatus.COURSE_NOT_PUBLIC,
-                String.format("Course with id %s is not public in Sisu", course.realisationId));
         } else if (endedMoreThanYearAgo(cur)) {
             return item.completeEnrichmentPhase(
                 EnrichmentStatus.COURSE_ENDED,

--- a/src/main/java/fi/helsinki/moodi/service/synchronize/process/SynchronizingProcessor.java
+++ b/src/main/java/fi/helsinki/moodi/service/synchronize/process/SynchronizingProcessor.java
@@ -248,21 +248,22 @@ public class SynchronizingProcessor extends AbstractProcessor {
 
         final StudyRegistryCourseUnitRealisation course = item.getStudyRegistryCourse().get();
 
-        Stream<UserSynchronizationItem> studentItemStream = course.students
+        List<UserSynchronizationItem> personItems = new ArrayList<>();
+
+        personItems.addAll(course.students
             .stream()
-            .map(UserSynchronizationItem::new);
-        Stream<UserSynchronizationItem> teacherItemStream = course.teachers
+            .map(UserSynchronizationItem::new).collect(Collectors.toList()));
+        personItems.addAll(course.teachers
             .stream()
-            .map(UserSynchronizationItem::new);
-        Stream<UserSynchronizationItem> creatorItemStream = Stream.empty();
+            .map(UserSynchronizationItem::new).collect(Collectors.toList()));
         if (item.getCourse().creatorUsername != null) {
             StudyRegistryTeacher creator = new StudyRegistryTeacher();
             creator.userName = item.getCourse().creatorUsername;
-            creatorItemStream = Stream.of(new UserSynchronizationItem(creator));
+            personItems.add(new UserSynchronizationItem(creator));
         }
 
         Map<Boolean, List<UserSynchronizationItem>> userSynchronizationItemsByCompletedStatus =
-            Stream.concat(creatorItemStream, Stream.concat(studentItemStream, teacherItemStream))
+            personItems.stream()
                 .map(i -> i.withMoodleCourseId(item.getCourse().moodleId))
                 .map(this::enrichWithMoodleUser)
                 .collect(Collectors.groupingBy(UserSynchronizationItem::isCompleted));

--- a/src/main/resources/db/migration/common/V012.00__add_creator_username.sql
+++ b/src/main/resources/db/migration/common/V012.00__add_creator_username.sql
@@ -1,0 +1,2 @@
+ALTER TABLE course
+    ADD creator_username varchar(128);

--- a/src/test/java/fi/helsinki/moodi/service/synchronize/enrich/SisuCourseEnricherTest.java
+++ b/src/test/java/fi/helsinki/moodi/service/synchronize/enrich/SisuCourseEnricherTest.java
@@ -52,13 +52,13 @@ public class SisuCourseEnricherTest extends AbstractMoodiIntegrationTest  {
     }
 
     @Test
-    public void thatSynchronizationItemIsSetToNotPublicStatusWhenCourseIsNotPublic() {
+    public void thatUnPublishedCourseGetsEnriched() {
         setUpMockSisuAndPrefetchCourses();
-        SynchronizationItem synchronizationItem = createFullSynchronizationItem("hy-CUR-archived");
+        SynchronizationItem synchronizationItem = createFullSynchronizationItem("hy-CUR-unpublished");
 
         SynchronizationItem enrichedItem = sisuCourseEnricher.doEnrich(synchronizationItem);
 
-        assertStatus(enrichedItem, EnrichmentStatus.COURSE_NOT_PUBLIC, false);
+        assertStatus(enrichedItem, EnrichmentStatus.IN_PROGESS, true);
     }
 
     @Test

--- a/src/test/java/fi/helsinki/moodi/service/synchronize/process/SynchronizingProcessorTest.java
+++ b/src/test/java/fi/helsinki/moodi/service/synchronize/process/SynchronizingProcessorTest.java
@@ -156,7 +156,6 @@ public class SynchronizingProcessorTest extends AbstractMoodiIntegrationTest {
         synchronizingProcessor.doProcess(item);
     }
 
-
     @Test
     public void thatUserIsNotEnrolledWithOnlyMoodiRoleIfNotApproved() {
         SynchronizationItem item = new CourseSynchronizationRequestChain(MOODLE_COURSE_ID)

--- a/src/test/java/fi/helsinki/moodi/service/synchronize/process/SynchronizingProcessorTest.java
+++ b/src/test/java/fi/helsinki/moodi/service/synchronize/process/SynchronizingProcessorTest.java
@@ -141,6 +141,23 @@ public class SynchronizingProcessorTest extends AbstractMoodiIntegrationTest {
     }
 
     @Test
+    public void thatCreatorIsEnrolledWithTeacherAndMoodiRoles() {
+        String creatorUsername = "jotain@helsinki.fi";
+        expectGetUserRequestToMoodle(creatorUsername, MOODLE_USER_ID);
+        SynchronizationItem item = new CourseSynchronizationRequestChain(MOODLE_COURSE_ID)
+            .withCreator(creatorUsername)
+            .withEmptyMoodleEnrollments()
+            .expectAddEnrollmentsToMoodleCourse(
+                teacherEnrollment(),
+                moodiEnrollment()
+            )
+            .getSynchronizationItem();
+
+        synchronizingProcessor.doProcess(item);
+    }
+
+
+    @Test
     public void thatUserIsNotEnrolledWithOnlyMoodiRoleIfNotApproved() {
         SynchronizationItem item = new CourseSynchronizationRequestChain(MOODLE_COURSE_ID)
             .withOodiStudent(MOODLE_USER_ID, false)
@@ -431,6 +448,11 @@ public class SynchronizingProcessorTest extends AbstractMoodiIntegrationTest {
             this.courseUnitRealisation.teachers.add(oodiTeacher.toStudyRegistryTeacher());
             teacherMap.put(moodleUserId, oodiTeacher.toStudyRegistryTeacher());
 
+            return this;
+        }
+
+        public CourseSynchronizationRequestChain withCreator(String creatorUsername) {
+            this.synchronizationItem.getCourse().creatorUsername = creatorUsername;
             return this;
         }
 

--- a/src/test/java/fi/helsinki/moodi/test/AbstractMoodiIntegrationTest.java
+++ b/src/test/java/fi/helsinki/moodi/test/AbstractMoodiIntegrationTest.java
@@ -101,7 +101,7 @@ public abstract class AbstractMoodiIntegrationTest {
     protected static final String MOODLE_USERNAME_CREATOR = "creator@helsinki.fi";
 
     protected static final String CREATOR_SISU_ID = "hy-hlo-creator";
-    protected static final String PERSON_NOT_FOUND = "hy-hlo-not-found";
+    protected static final String PERSON_NOT_FOUND_ID = "hy-hlo-not-found";
 
     private static final String MOODLE_EMPTY_LIST_RESPONSE = "[]";
     protected static final String MOODLE_ERROR_RESPONSE =

--- a/src/test/java/fi/helsinki/moodi/test/AbstractMoodiIntegrationTest.java
+++ b/src/test/java/fi/helsinki/moodi/test/AbstractMoodiIntegrationTest.java
@@ -332,6 +332,7 @@ public abstract class AbstractMoodiIntegrationTest {
     protected final ResultActions makeCreateCourseRequest(final String realisationId) throws Exception {
         return makeCreateCourseRequest(realisationId, null);
     }
+
     protected final ResultActions makeCreateCourseRequest(final String realisationId, final String creatorSisuId) throws Exception {
         ImportCourseRequest importCourseRequest = new ImportCourseRequest();
         importCourseRequest.realisationId = realisationId;

--- a/src/test/java/fi/helsinki/moodi/web/AbstractSuccessfulCreateCourseTest.java
+++ b/src/test/java/fi/helsinki/moodi/web/AbstractSuccessfulCreateCourseTest.java
@@ -89,7 +89,7 @@ public abstract class AbstractSuccessfulCreateCourseTest extends AbstractMoodiIn
             expectedEnrollments.add(2, new MoodleEnrollment(getStudentRoleId(), MOODLE_USER_ID_MAKE, MOODLE_COURSE_ID));
         }
         if (creatorSisuId != null) {
-            expectedEnrollments.add(expectedEnrollments.size(), new MoodleEnrollment(getTeacherRoleId(), MOODLE_USER_CREATOR, MOODLE_COURSE_ID));
+            expectedEnrollments.add(new MoodleEnrollment(getTeacherRoleId(), MOODLE_USER_CREATOR, MOODLE_COURSE_ID));
         }
         expectEnrollmentsWithAddedMoodiRoles(expectedEnrollments);
     }

--- a/src/test/java/fi/helsinki/moodi/web/AbstractSuccessfulCreateCourseTest.java
+++ b/src/test/java/fi/helsinki/moodi/web/AbstractSuccessfulCreateCourseTest.java
@@ -30,16 +30,16 @@ public abstract class AbstractSuccessfulCreateCourseTest extends AbstractMoodiIn
     protected static final String SISU_COURSE_REALISATION_ID = "hy-CUR-123";
     protected static final String EXPECTED_SISU_DESCRIPTION_TO_MOODLE = "https%3A%2F%2Fcourses.helsinki.fi%2Ffi%2FOODI-FLOW%2F136394381";
 
-    protected void expectEnrollmentsWithAddedMoodiRoles(List<MoodleEnrollment> moodleEnrollments) {
+protected void expectEnrollmentsWithAddedMoodiRoles(List<MoodleEnrollment> moodleEnrollments) {
         expectEnrollmentRequestToMoodle(moodleEnrollments.stream()
             .flatMap(enrollment -> Stream.of(enrollment,
                 new MoodleEnrollment(getMoodiRoleId(), enrollment.moodleUserId, enrollment.moodleCourseId))).toArray(MoodleEnrollment[]::new));
     }
 
-    protected void setUpMockServerResponsesForSisuCourse123(boolean allUsersFound) {
-        setUpSisuResponsesFor123();
+    protected void setUpMockServerResponsesForSisuCourse123(boolean allUsersFound, String creatorSisuId) {
+        setUpSisuResponsesFor123(creatorSisuId);
         expectSisuOrganisationExportRequest();
-        setUpMoodleResponses(SISU_COURSE_REALISATION_ID, EXPECTED_SISU_DESCRIPTION_TO_MOODLE, "sisu_", allUsersFound, "9");
+        setUpMoodleResponses(SISU_COURSE_REALISATION_ID, EXPECTED_SISU_DESCRIPTION_TO_MOODLE, "sisu_", allUsersFound, "9", creatorSisuId);
     }
 
     protected void setUpSisuResponseCourse123NotFound() {
@@ -47,13 +47,23 @@ public abstract class AbstractSuccessfulCreateCourseTest extends AbstractMoodiIn
                 "/sisu/course-unit-realisation-not-found.json");
     }
 
-    protected void setUpSisuResponsesFor123() {
+    protected void setUpSisuResponsesFor123(String creatorSisuId) {
+        if (creatorSisuId != null) {
+            setUpGetCreatorCall(creatorSisuId);
+        }
         mockSisuGraphQLServer.expectCourseUnitRealisationsRequest(Arrays.asList(SISU_COURSE_REALISATION_ID),
                 "/sisu/course-unit-realisation.json");
         mockSisuGraphQLServer.expectPersonsRequest(Arrays.asList("hy-hlo-4"), "/sisu/persons.json");
     }
 
-    protected void setUpMoodleResponses(String curId, String description, String moodleCourseIdPrefix, boolean allUsersFound, String categoryId) {
+    protected void setUpGetCreatorCall(String creatorSisuId) {
+        mockSisuGraphQLServer.expectPersonsRequest(Arrays.asList(creatorSisuId),
+            CREATOR_SISU_ID.equals(creatorSisuId) ?
+                "/sisu/persons-hy-hlo-creator.json" :
+                "/sisu/persons-not-found.json");
+    }
+
+    protected void setUpMoodleResponses(String curId, String description, String moodleCourseIdPrefix, boolean allUsersFound, String categoryId, String creatorSisuId) {
         expectCreateCourseRequestToMoodle(curId, moodleCourseIdPrefix, description, MOODLE_COURSE_ID, categoryId);
 
         expectGetUserRequestToMoodle(MOODLE_USERNAME_NIINA, MOODLE_USER_ID_NIINA);
@@ -64,20 +74,22 @@ public abstract class AbstractSuccessfulCreateCourseTest extends AbstractMoodiIn
             expectGetUserRequestToMoodleUserNotFound(MOODLE_USERNAME_MAKE);
         }
         expectGetUserRequestToMoodle(MOODLE_USERNAME_HRAOPE, MOODLE_USER_HRAOPE);
+        if (creatorSisuId != null) {
+            expectGetUserRequestToMoodle(MOODLE_USERNAME_CREATOR, MOODLE_USER_CREATOR);
+        }
+
+        List<MoodleEnrollment> expectedEnrollments = Lists.newArrayList(
+            new MoodleEnrollment(getStudentRoleId(), MOODLE_USER_ID_NIINA, MOODLE_COURSE_ID),
+            new MoodleEnrollment(getStudentRoleId(), MOODLE_USER_ID_JUKKA, MOODLE_COURSE_ID),
+            new MoodleEnrollment(getTeacherRoleId(), MOODLE_USER_HRAOPE, MOODLE_COURSE_ID)
+        );
 
         if (allUsersFound) {
-            expectEnrollmentsWithAddedMoodiRoles(Lists.newArrayList(
-                new MoodleEnrollment(getStudentRoleId(), MOODLE_USER_ID_NIINA, MOODLE_COURSE_ID),
-                new MoodleEnrollment(getStudentRoleId(), MOODLE_USER_ID_JUKKA, MOODLE_COURSE_ID),
-                new MoodleEnrollment(getStudentRoleId(), MOODLE_USER_ID_MAKE, MOODLE_COURSE_ID),
-                new MoodleEnrollment(getTeacherRoleId(), MOODLE_USER_HRAOPE, MOODLE_COURSE_ID)
-            ));
-        } else {
-            expectEnrollmentsWithAddedMoodiRoles(Lists.newArrayList(
-                new MoodleEnrollment(getStudentRoleId(), MOODLE_USER_ID_NIINA, MOODLE_COURSE_ID),
-                new MoodleEnrollment(getStudentRoleId(), MOODLE_USER_ID_JUKKA, MOODLE_COURSE_ID),
-                new MoodleEnrollment(getTeacherRoleId(), MOODLE_USER_HRAOPE, MOODLE_COURSE_ID)
-            ));
+            expectedEnrollments.add(2, new MoodleEnrollment(getStudentRoleId(), MOODLE_USER_ID_MAKE, MOODLE_COURSE_ID));
         }
+        if (creatorSisuId != null) {
+            expectedEnrollments.add(expectedEnrollments.size(), new MoodleEnrollment(getTeacherRoleId(), MOODLE_USER_CREATOR, MOODLE_COURSE_ID));
+        }
+        expectEnrollmentsWithAddedMoodiRoles(expectedEnrollments);
     }
 }

--- a/src/test/java/fi/helsinki/moodi/web/AbstractSuccessfulCreateCourseTest.java
+++ b/src/test/java/fi/helsinki/moodi/web/AbstractSuccessfulCreateCourseTest.java
@@ -30,7 +30,7 @@ public abstract class AbstractSuccessfulCreateCourseTest extends AbstractMoodiIn
     protected static final String SISU_COURSE_REALISATION_ID = "hy-CUR-123";
     protected static final String EXPECTED_SISU_DESCRIPTION_TO_MOODLE = "https%3A%2F%2Fcourses.helsinki.fi%2Ffi%2FOODI-FLOW%2F136394381";
 
-protected void expectEnrollmentsWithAddedMoodiRoles(List<MoodleEnrollment> moodleEnrollments) {
+    protected void expectEnrollmentsWithAddedMoodiRoles(List<MoodleEnrollment> moodleEnrollments) {
         expectEnrollmentRequestToMoodle(moodleEnrollments.stream()
             .flatMap(enrollment -> Stream.of(enrollment,
                 new MoodleEnrollment(getMoodiRoleId(), enrollment.moodleUserId, enrollment.moodleCourseId))).toArray(MoodleEnrollment[]::new));
@@ -63,7 +63,8 @@ protected void expectEnrollmentsWithAddedMoodiRoles(List<MoodleEnrollment> moodl
                 "/sisu/persons-not-found.json");
     }
 
-    protected void setUpMoodleResponses(String curId, String description, String moodleCourseIdPrefix, boolean allUsersFound, String categoryId, String creatorSisuId) {
+    protected void setUpMoodleResponses(String curId, String description, String moodleCourseIdPrefix,
+                                        boolean allUsersFound, String categoryId, String creatorSisuId) {
         expectCreateCourseRequestToMoodle(curId, moodleCourseIdPrefix, description, MOODLE_COURSE_ID, categoryId);
 
         expectGetUserRequestToMoodle(MOODLE_USERNAME_NIINA, MOODLE_USER_ID_NIINA);

--- a/src/test/java/fi/helsinki/moodi/web/CreateCourseTest.java
+++ b/src/test/java/fi/helsinki/moodi/web/CreateCourseTest.java
@@ -38,10 +38,11 @@ public class CreateCourseTest extends AbstractSuccessfulCreateCourseTest {
     private ImportingService importingService;
 
     private static String COURSE_NOT_FOUND_MESSAGE = "Study registry course not found with realisation id %s (%s)";
+    private static String PERSON_NOT_FOUND_MESSAGE = "Sisu person not found with id %s";
 
     @Test
     public void successfulCreateCourseBySisuIDReturnsCorrectResponse() throws Exception {
-        setUpMockServerResponsesForSisuCourse123(true);
+        setUpMockServerResponsesForSisuCourse123(true, null);
 
         makeCreateCourseRequest(SISU_COURSE_REALISATION_ID)
             .andExpect(status().isOk())
@@ -50,7 +51,7 @@ public class CreateCourseTest extends AbstractSuccessfulCreateCourseTest {
 
     @Test
     public void successfulCreateCourseByOodiNativeIDUsesSisuAndReturnsCorrectResponse() throws Exception {
-        setUpMockServerResponsesForSisuCourse123(true);
+        setUpMockServerResponsesForSisuCourse123(true, null);
 
         makeCreateCourseRequest("123")
             .andExpect(status().isOk())
@@ -81,7 +82,7 @@ public class CreateCourseTest extends AbstractSuccessfulCreateCourseTest {
     @Test
     public void thatIfFirstImportFailsTheSecondImportCanSucceed() throws Exception {
         // Set up first try to get a server error from Moodle.
-        setUpSisuResponsesFor123();
+        setUpSisuResponsesFor123(null);
         expectSisuOrganisationExportRequest();
 
         moodleMockServer.expect(requestTo(getMoodleRestUrl()))
@@ -92,8 +93,8 @@ public class CreateCourseTest extends AbstractSuccessfulCreateCourseTest {
             .andRespond(withServerError());
 
         // Set up second try to succeed. Sisu organisation call is not made, as it is cached.
-        setUpSisuResponsesFor123();
-        setUpMoodleResponses(SISU_COURSE_REALISATION_ID, EXPECTED_SISU_DESCRIPTION_TO_MOODLE, "sisu_", true, "9");
+        setUpSisuResponsesFor123(null);
+        setUpMoodleResponses(SISU_COURSE_REALISATION_ID, EXPECTED_SISU_DESCRIPTION_TO_MOODLE, "sisu_", true, "9", null);
 
         // First try.
         makeCreateCourseRequest(SISU_COURSE_REALISATION_ID)
@@ -113,6 +114,25 @@ public class CreateCourseTest extends AbstractSuccessfulCreateCourseTest {
             .andExpect(jsonPath("$.data.moodleCourseId").value(toIntExact(MOODLE_COURSE_ID)));
 
         assertEquals("COMPLETED", importingService.getImportedCourse(SISU_COURSE_REALISATION_ID).importStatus);
+    }
+
+    @Test
+    public void thatImportingWithCeatorSisuIdWorks() throws Exception {
+        setUpMockServerResponsesForSisuCourse123(true, CREATOR_SISU_ID);
+
+        makeCreateCourseRequest(SISU_COURSE_REALISATION_ID, CREATOR_SISU_ID)
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.data.moodleCourseId").value(toIntExact(MOODLE_COURSE_ID)));
+    }
+
+    @Test
+    public void thatImportingWithNotFoundCeatorSisuIdThrowsException() throws Exception {
+        setUpGetCreatorCall(PERSON_NOT_FOUND);
+
+        makeCreateCourseRequest(SISU_COURSE_REALISATION_ID, PERSON_NOT_FOUND)
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.error")
+                .value(String.format(PERSON_NOT_FOUND_MESSAGE, PERSON_NOT_FOUND)));
     }
 }
 

--- a/src/test/java/fi/helsinki/moodi/web/CreateCourseTest.java
+++ b/src/test/java/fi/helsinki/moodi/web/CreateCourseTest.java
@@ -117,7 +117,7 @@ public class CreateCourseTest extends AbstractSuccessfulCreateCourseTest {
     }
 
     @Test
-    public void thatImportingWithCeatorSisuIdWorks() throws Exception {
+    public void thatImportingWithCreatorSisuIdWorks() throws Exception {
         setUpMockServerResponsesForSisuCourse123(true, CREATOR_SISU_ID);
 
         makeCreateCourseRequest(SISU_COURSE_REALISATION_ID, CREATOR_SISU_ID)
@@ -126,13 +126,13 @@ public class CreateCourseTest extends AbstractSuccessfulCreateCourseTest {
     }
 
     @Test
-    public void thatImportingWithNotFoundCeatorSisuIdThrowsException() throws Exception {
-        setUpGetCreatorCall(PERSON_NOT_FOUND);
+    public void thatImportingWithNotFoundCreatorSisuIdThrowsException() throws Exception {
+        setUpGetCreatorCall(PERSON_NOT_FOUND_ID);
 
-        makeCreateCourseRequest(SISU_COURSE_REALISATION_ID, PERSON_NOT_FOUND)
+        makeCreateCourseRequest(SISU_COURSE_REALISATION_ID, PERSON_NOT_FOUND_ID)
             .andExpect(status().isNotFound())
             .andExpect(jsonPath("$.error")
-                .value(String.format(PERSON_NOT_FOUND_MESSAGE, PERSON_NOT_FOUND)));
+                .value(String.format(PERSON_NOT_FOUND_MESSAGE, PERSON_NOT_FOUND_ID)));
     }
 }
 

--- a/src/test/java/fi/helsinki/moodi/web/GetCourseAndEnrollmentStatusTest.java
+++ b/src/test/java/fi/helsinki/moodi/web/GetCourseAndEnrollmentStatusTest.java
@@ -30,7 +30,7 @@ public class GetCourseAndEnrollmentStatusTest extends AbstractSuccessfulCreateCo
 
     @Before
     public void setUp() {
-        setUpMockServerResponsesForSisuCourse123(true);
+        setUpMockServerResponsesForSisuCourse123(true, null);
     }
 
     @Test

--- a/src/test/java/fi/helsinki/moodi/web/SuccessfulCreateCourseWithEnrollmentWarningsTest.java
+++ b/src/test/java/fi/helsinki/moodi/web/SuccessfulCreateCourseWithEnrollmentWarningsTest.java
@@ -27,7 +27,7 @@ public class SuccessfulCreateCourseWithEnrollmentWarningsTest extends AbstractSu
 
     @Before
     public void setUp() {
-        setUpMockServerResponsesForSisuCourse123(false);
+        setUpMockServerResponsesForSisuCourse123(false, null);
     }
 
     @Test

--- a/src/test/resources/fixtures/sisu-itest/persons-itest.json
+++ b/src/test/resources/fixtures/sisu-itest/persons-itest.json
@@ -4,7 +4,7 @@
       {{#teachers}}
       {
         "id": "{{ personId }}",
-        "studentNumber": "{{ personId }}",
+        "studentNumber": null,
         "firstNames": "Herra",
         "lastName": "Opettaja",
         "employeeNumber": "aivansama",

--- a/src/test/resources/fixtures/sisu/course-unit-realisations-2.json
+++ b/src/test/resources/fixtures/sisu/course-unit-realisations-2.json
@@ -84,6 +84,46 @@
             "language": "fi"
           }
         ]
+      },
+      {
+        "name": {
+          "fi": "Julkaisematon 5",
+          "sv": "Kurs 5",
+          "en": "Unpublished 5"
+        },
+        "teachingLanguageUrn": "urn:code:language:fi",
+        "id": "hy-CUR-unpublished",
+        "activityPeriod": {
+          "startDate": "2039-08-05",
+          "endDate": "2039-11-05"
+        },
+        "flowState": "DRAFT",
+        "responsibilityInfos": [
+          {
+            "roleUrn": "urn:code:course-unit-realisation-responsibility-info-type:responsible-teacher",
+            "personId": "hy-hlo-4"
+          },
+          {
+            "roleUrn": "urn:code:course-unit-realisation-responsibility-info-type:someone-else",
+            "personId": "hy-hlo-not-a-teacher"
+          }
+        ],
+        "enrolments": [
+          {
+            "state": "ENROLLED",
+            "person": {
+              "eduPersonPrincipalName": "niina4@helsinki.fi"
+            }
+          }
+        ],
+        "learningEnvironments": [
+          {
+            "name": "Kurssisivu",
+            "url": "https://courses.helsinki.fi/fi/OODI-FLOW/136394381",
+            "primary": true,
+            "language": "fi"
+          }
+        ]
       }
     ]
   }

--- a/src/test/resources/fixtures/sisu/persons-hy-hlo-creator.json
+++ b/src/test/resources/fixtures/sisu/persons-hy-hlo-creator.json
@@ -1,0 +1,14 @@
+{
+  "data": {
+    "private_persons": [
+      {
+        "id": "hy-hlo-creator",
+        "studentNumber": null,
+        "firstNames": "John",
+        "lastName": "Creator",
+        "employeeNumber": "7",
+        "eduPersonPrincipalName": "creator@helsinki.fi"
+      }
+    ]
+  }
+}

--- a/src/test/resources/fixtures/sisu/persons-not-found.json
+++ b/src/test/resources/fixtures/sisu/persons-not-found.json
@@ -1,0 +1,48 @@
+{
+  "errors": [
+    {
+      "message": "PrivatePerson 404: Not Found",
+      "locations": [
+        {
+          "line": 2,
+          "column": 3
+        }
+      ],
+      "path": [
+        "private_persons"
+      ],
+      "extensions": {
+        "code": "INTERNAL_SERVER_ERROR",
+        "response": {
+          "body": {
+            "cause": null,
+            "stackTrace": [],
+            "deeper": [],
+            "message": "PrivatePersonStore#hy-hlo-not-found",
+            "suppressed": [],
+            "localizedMessage": "PrivatePersonStore#hy-hlo-not-found"
+          },
+          "url": "http://localhost/ori/api/persons?id=hy-hlo-not-found",
+          "status": 404,
+          "statusText": "Not Found"
+        },
+        "exception": {
+          "stacktrace": [
+            "Error: 404: Not Found",
+            "    at h.<anonymous> (/app/dist/index.js:1:3570)",
+            "    at Generator.next (<anonymous>)",
+            "    at /app/dist/index.js:1:1437",
+            "    at new Promise (<anonymous>)",
+            "    at i (/app/dist/index.js:1:1182)",
+            "    at h.errorFromResponse (/app/dist/index.js:1:3390)",
+            "    at h.<anonymous> (/app/dist/index.js:1:3287)",
+            "    at Generator.next (<anonymous>)",
+            "    at /app/dist/index.js:1:1437",
+            "    at new Promise (<anonymous>)"
+          ]
+        }
+      }
+    }
+  ],
+  "data": null
+}


### PR DESCRIPTION
https://jira.it.helsinki.fi/browse/MOODI-147 Lisätään kurssialueen luonut käyttäjä Moodle-kurssialueen opettajaksi
- The import API now accepts the Sisu personId of the user importing the course. 
- The course creator username is fetched from Sisu and stored in the DB, and the user is enrolled as a teacher when creating the course in Moodle, and during sync.
- MockSisuGraphQLServer now supports verifying expectations after tests.
- Moodle integration tests now verify expectations after tests.
- Fixed handling of a not found person in SisuClient.