### PR TITLE
https://jira.it.helsinki.fi/browse/MOODI-145 Parannetaan health check…

### DIFF
--- a/src/main/java/fi/helsinki/moodi/MoodiHealthIndicator.java
+++ b/src/main/java/fi/helsinki/moodi/MoodiHealthIndicator.java
@@ -33,7 +33,7 @@ import java.util.Optional;
 
 @Component
 public class MoodiHealthIndicator implements HealthIndicator {
-    private static final int MAX_HOURS_SINCE_COMPLETED_SYNC = 3;
+    private static final int MAX_HOURS_SINCE_COMPLETED_SYNC = 4;
     private static final int MIN_MINUTES_SINCE_ERROR = 30;
     private Error reportedError;
 
@@ -49,7 +49,7 @@ public class MoodiHealthIndicator implements HealthIndicator {
     }
 
     // Return DOWN, if
-    // - a sync job has not completed SUCCESSFULLY within 3 hours.
+    // - a sync job has not completed SUCCESSFULLY within 4 hours.
     // - an important API action has failed within 30 minutes, and has not succeeded since.
     @Override
     public Health health() {
@@ -63,7 +63,7 @@ public class MoodiHealthIndicator implements HealthIndicator {
                         return indicateError(String.format("No sync job completed in %d hours. Latest job completed at %s UTC",
                             MAX_HOURS_SINCE_COMPLETED_SYNC, latest.completed));
                     } else if (latest.status != SynchronizationStatus.COMPLETED_SUCCESS) {
-                        return indicateError(String.format("Status of the last sync job is not COMPLETED_SUCCESS, but %s", latest.message));
+                        return indicateError(String.format("The last sync job failed: %s", latest.message));
                     }
                 } else {
                     return indicateError("No sync jobs in the DB.");

--- a/src/main/java/fi/helsinki/moodi/integration/moodle/MoodleCourseData.java
+++ b/src/main/java/fi/helsinki/moodi/integration/moodle/MoodleCourseData.java
@@ -20,7 +20,6 @@ package fi.helsinki.moodi.integration.moodle;
 public final class MoodleCourseData {
 
     public long id;
-    public String shortname;
 
     public MoodleCourseData() {}
 

--- a/src/main/java/fi/helsinki/moodi/service/log/SynchronizationSummaryLog.java
+++ b/src/main/java/fi/helsinki/moodi/service/log/SynchronizationSummaryLog.java
@@ -75,7 +75,7 @@ public class SynchronizationSummaryLog {
                 item.getProcessingStatus(),
                 new UserEnrollmentsLogEntry(
                     getEnrollmentDetailsSummary(userSyncronizationItemLogEntries),
-                    getEnrollmentResults(userSyncronizationItemLogEntries)),
+                    getFailedEnrollmentResults(userSyncronizationItemLogEntries)),
                 item.getEnrichmentMessage(),
                 item.getProcessingMessage()
             );
@@ -89,9 +89,9 @@ public class SynchronizationSummaryLog {
         return items.stream().collect(Collectors.groupingBy(item -> item.status, Collectors.counting()));
     }
 
-    private static Map<UserSynchronizationItemStatus, List<UserSyncronizationItemLogEntry>> getEnrollmentResults(
+    private static Map<UserSynchronizationItemStatus, List<UserSyncronizationItemLogEntry>> getFailedEnrollmentResults(
         List<UserSyncronizationItemLogEntry> items) {
-        return items.stream().collect(Collectors.groupingBy(item -> item.status));
+        return items.stream().filter(i -> i.status != UserSynchronizationItemStatus.SUCCESS).collect(Collectors.groupingBy(item -> item.status));
     }
 
     public static class SynchronizationSymmaryLogRoot {

--- a/src/main/java/fi/helsinki/moodi/service/synchronize/SynchronizationItem.java
+++ b/src/main/java/fi/helsinki/moodi/service/synchronize/SynchronizationItem.java
@@ -152,8 +152,7 @@ public final class SynchronizationItem {
     }
 
     public SynchronizationItem completeProcessingPhase() {
-
-        final boolean newSuccess = userSynchronizationItems.stream().allMatch(UserSynchronizationItem::isSuccess);
+        final boolean newSuccess = userSynchronizationItems.stream().allMatch(i -> i.isSuccess() || i.isMoodleUserNotFound());
 
         final String newMessage = (newSuccess) ? SUCCESS_MESSAGE : ENROLLMENT_FAILURES_MESSAGE;
 

--- a/src/main/java/fi/helsinki/moodi/service/synchronize/SynchronizationService.java
+++ b/src/main/java/fi/helsinki/moodi/service/synchronize/SynchronizationService.java
@@ -134,7 +134,7 @@ public class SynchronizationService {
     }
 
     /**
-     * Process items, that is perform the actual synchronization.
+     * Perform the actual synchronization.
      */
     private List<SynchronizationItem> processItems(final List<SynchronizationItem> items) {
         return processorService.process(items);

--- a/src/main/java/fi/helsinki/moodi/service/synchronize/SynchronizationSummary.java
+++ b/src/main/java/fi/helsinki/moodi/service/synchronize/SynchronizationSummary.java
@@ -67,7 +67,7 @@ public final class SynchronizationSummary {
     }
 
     public String getMessage() {
-        String ret = getStatus().name();
+        String ret = String.format("%s with %d/%d failures", getStatus().name(), getFailedItemsCount(), getItemCount());
         if (exception != null) {
             // DB column is varchar 2000, but we might have non-ascii characters in our message, so we truncate it to 1000 characters.
             ret += " : " + StringUtils.substring(exception.getMessage(), 0, 1000);

--- a/src/main/java/fi/helsinki/moodi/service/synchronize/process/UserSynchronizationItem.java
+++ b/src/main/java/fi/helsinki/moodi/service/synchronize/process/UserSynchronizationItem.java
@@ -107,6 +107,10 @@ public class UserSynchronizationItem {
         return UserSynchronizationItemStatus.SUCCESS.equals(status);
     }
 
+    public boolean isMoodleUserNotFound() {
+        return UserSynchronizationItemStatus.MOODLE_USER_NOT_FOUND.equals(status);
+    }
+
     public List<UserSynchronizationAction> getActions() {
         return actions;
     }

--- a/src/test/java/fi/helsinki/moodi/service/log/SynchronizationSummaryLogTest.java
+++ b/src/test/java/fi/helsinki/moodi/service/log/SynchronizationSummaryLogTest.java
@@ -86,7 +86,7 @@ public class SynchronizationSummaryLogTest extends AbstractSummaryLogTest {
         SynchronizationSummary summary = new SynchronizationSummary(synchronizationType, synchronizationItems, Stopwatch.createUnstarted(),
                 new RuntimeException("Voi minnuu!"));
 
-        assertEquals("COMPLETED_FAILURE : Voi minnuu!", summary.getMessage());
+        assertEquals("COMPLETED_FAILURE with 1/1 failures : Voi minnuu!", summary.getMessage());
 
         SynchronizationSummaryLog synchronizationSummaryLog = new SynchronizationSummaryLog(summary);
 
@@ -114,23 +114,8 @@ public class SynchronizationSummaryLogTest extends AbstractSummaryLogTest {
         List<UserSyncronizationItemLogEntry> successfullUserEntries = synchronizationItemLogEntryResults.get(UserSynchronizationItemStatus.SUCCESS);
         List<UserSyncronizationItemLogEntry> failedUserEntries = synchronizationItemLogEntryResults.get(UserSynchronizationItemStatus.ERROR);
 
-        assertEquals(1, successfullUserEntries.size());
+        assertNull(successfullUserEntries); // Leave out all the successful entries to have less noise in the log.
         assertEquals(1, failedUserEntries.size());
-
-        UserSyncronizationItemLogEntry successfulEntry = successfullUserEntries.get(0);
-
-        assertTrue(successfulEntry.status.equals(UserSynchronizationItemStatus.SUCCESS));
-        assertTrue(successfulEntry.moodleUserId.equals(STUDENT_MOODLE_USER_ID));
-        assertEquals(STUDENT_NUMBER, successfulEntry.student.studentNumber);
-        assertTrue(successfulEntry.student.isEnrolled);
-        assertNull(successfulEntry.teacher);
-        assertSingleAction(
-            successfulEntry.actions,
-            UserSynchronizationActionStatus.SUCCESS,
-            UserSynchronizationActionType.REMOVE_ROLES,
-            newArrayList(STUDENT_ROLE_ID));
-        assertEquals(STUDENT_MOODLE_USERNAME, successfulEntry.moodleUsername);
-        assertEquals(singletonList(STUDENT_ROLE_ID), successfulEntry.moodleRoleIds);
 
         UserSyncronizationItemLogEntry failedEntry = failedUserEntries.get(0);
         assertTrue(failedEntry.status.equals(UserSynchronizationItemStatus.ERROR));
@@ -158,7 +143,6 @@ public class SynchronizationSummaryLogTest extends AbstractSummaryLogTest {
         assertEquals(expectedActionType, action.actionType);
         assertEquals(action.roles.size(), expectedRoles.size());
         assertTrue(action.roles.containsAll(expectedRoles));
-
     }
 
     private SynchronizationItem getSynchronizationItem(SynchronizationType synchronizationType) {

--- a/src/test/java/fi/helsinki/moodi/web/HealthCheckTest.java
+++ b/src/test/java/fi/helsinki/moodi/web/HealthCheckTest.java
@@ -115,18 +115,18 @@ public class HealthCheckTest extends AbstractMoodiIntegrationTest {
             .andExpect(status().is5xxServerError())
             .andExpect(jsonPath("$.status").value("DOWN"))
             .andExpect(jsonPath("$.details.moodi.details.error")
-                .value("Status of the last sync job is not COMPLETED_SUCCESS, but COMPLETED_FAILURE"));
+                .value("The last sync job failed: COMPLETED_FAILURE"));
     }
 
     @Test
-    public void thatReturnsErrorWhenNoJobCompletedInThreeHours() throws Exception {
-        LocalDateTime fourHoursAgo = setupJobRunHoursAgo(4);
+    public void thatReturnsErrorWhenNoJobCompletedInFourHours() throws Exception {
+        LocalDateTime fiveHoursAgo = setupJobRunHoursAgo(5);
 
         mockMvc.perform(get("/health"))
             .andExpect(status().is5xxServerError())
             .andExpect(jsonPath("$.status").value("DOWN"))
             .andExpect(jsonPath("$.details.moodi.details.error")
-                .value(String.format("No sync job completed in 3 hours. Latest job completed at %s UTC", fourHoursAgo)));
+                .value(String.format("No sync job completed in 4 hours. Latest job completed at %s UTC", fiveHoursAgo)));
     }
 
     @Test


### PR DESCRIPTION
… -toimintoa

- Moodle user not found is no longer considered a failure when syncing.
- Decreased the amount of sync logging by excluding details of successful UserSynchronizationItems from the log.
- Now reporting number of failed courses / total courses in synchronization summary message.
- Increased from 3 to 4 hours the time window during which a previous successful synchronization is considered green in the health check, because the sync takes close to an hour currently and is run every two hours.

Also, Moodi was running out of heap on prod.
- Increased memory for the JVM.
- Turned on heap dump on OOM
- Removed the unused field MoodleCourseData.shortName, which was taking most of the heap (there were 2.7 million instances of MoodleCourseData in a prod heap dump).