### PR TITLE
MOODI-154b use original sisu dates in course description

### DIFF
--- a/src/main/java/fi/helsinki/moodi/integration/sisu/SisuCourseUnitRealisation.java
+++ b/src/main/java/fi/helsinki/moodi/integration/sisu/SisuCourseUnitRealisation.java
@@ -108,9 +108,15 @@ public class SisuCourseUnitRealisation {
             + getLocalizedSpan(SisuLocale.EN, courseUnitRealisationType.name.getForLocaleOrDefault(SisuLocale.EN))
             + getLocalizedSpan(SisuLocale.SV, courseUnitRealisationType.name.getForLocaleOrDefault(SisuLocale.SV));
 
+        String courseDatesPart = "";
+        if (activityPeriod != null && activityPeriod.startDate != null) {
+            courseDatesPart = ", " + FINNISH_DATE_FORMAT.format(activityPeriod.startDate) +
+                (activityPeriod.endDate != null ? "–" + FINNISH_DATE_FORMAT.format(activityPeriod.endDate) : "");
+        }
+
         ret.description = "<p>" + localizedUrls + "</p>"
             + "<p>" + localizedCUNames + " " + courseUnitCodes + "</p>"
-            + "<p>" + localizedCUTypes + ", " + FINNISH_DATE_FORMAT.format(ret.startDate) + "-" + FINNISH_DATE_FORMAT.format(ret.endDate) + "</p>";
+            + "<p>" + localizedCUTypes + courseDatesPart + "</p>";
 
         return ret;
     }

--- a/src/test/java/fi/helsinki/moodi/service/importing/MoodleCourseBuilderTest.java
+++ b/src/test/java/fi/helsinki/moodi/service/importing/MoodleCourseBuilderTest.java
@@ -36,7 +36,6 @@ import java.util.Arrays;
 import static fi.helsinki.moodi.Constants.*;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
 
 public class MoodleCourseBuilderTest extends AbstractMoodiIntegrationTest {
 

--- a/src/test/java/fi/helsinki/moodi/service/importing/MoodleCourseBuilderTest.java
+++ b/src/test/java/fi/helsinki/moodi/service/importing/MoodleCourseBuilderTest.java
@@ -80,7 +80,7 @@ public class MoodleCourseBuilderTest extends AbstractMoodiIntegrationTest {
             "<p><span lang=\"fi\" class=\"multilang\">Opintojaksot</span><span lang=\"en\" class=\"multilang\">Courses</span>" +
             "<span lang=\"sv\" class=\"multilang\">Studieavsnitten</span> CODE1, CODE2, CODE3</p><p>" +
             "<span lang=\"fi\" class=\"multilang\">Kurssi</span><span lang=\"en\" class=\"multilang\">Course</span>" +
-            "<span lang=\"sv\" class=\"multilang\">Kurs</span>, 5.8.2019-5.12.2019</p>", moodleCourse.summary);
+            "<span lang=\"sv\" class=\"multilang\">Kurs</span>, 5.8.2019–5.11.2019</p>", moodleCourse.summary);
         assertEquals(LocalDate.of(2019, 8, 5), moodleCourse.startTime);
         assertEquals(LocalDate.of(2019, 12, 5), moodleCourse.endTime);
         assertEquals("9", moodleCourse.categoryId);
@@ -104,7 +104,7 @@ public class MoodleCourseBuilderTest extends AbstractMoodiIntegrationTest {
             "<p><span lang=\"fi\" class=\"multilang\">Opintojaksot</span><span lang=\"en\" class=\"multilang\">Courses</span>" +
             "<span lang=\"sv\" class=\"multilang\">Studieavsnitten</span> CODE1, CODE2, CODE3</p><p>" +
             "<span lang=\"fi\" class=\"multilang\">Kurssi</span><span lang=\"en\" class=\"multilang\">Course</span>" +
-            "<span lang=\"sv\" class=\"multilang\">Kurs</span>, 5.8.2019-5.12.2019</p>", moodleCourse.summary);
+            "<span lang=\"sv\" class=\"multilang\">Kurs</span>, 5.8.2019–5.11.2019</p>", moodleCourse.summary);
         assertEquals(LocalDate.of(2019, 8, 5), moodleCourse.startTime);
         assertEquals(LocalDate.of(2019, 12, 5), moodleCourse.endTime);
         assertEquals("9", moodleCourse.categoryId);
@@ -154,13 +154,13 @@ public class MoodleCourseBuilderTest extends AbstractMoodiIntegrationTest {
             + generateMultiLangSpan("en", REALISATION_NAME_EN), moodleCourse.fullName);
         assertEquals("hy-cur-1", moodleCourse.idNumber);
         assertEquals("Kurssin nimi-5YC1S", moodleCourse.shortName);
-        assertTrue(moodleCourse.summary.startsWith("<p><span lang=\"fi\" class=\"multilang\"><a href=\"urli suomeksi\">urli suomeksi</a></span>" +
+        assertEquals("<p><span lang=\"fi\" class=\"multilang\"><a href=\"urli suomeksi\">urli suomeksi</a></span>" +
             "<span lang=\"en\" class=\"multilang\"><a href=\"urli suomeksi\">urli suomeksi</a></span>" +
             "<span lang=\"sv\" class=\"multilang\"><a href=\"fel url på svenska\">fel url på svenska</a></span></p>" +
             "<p><span lang=\"fi\" class=\"multilang\">Opintojaksot</span><span lang=\"en\" class=\"multilang\">Courses</span>" +
             "<span lang=\"sv\" class=\"multilang\">Studieavsnitten</span> CODE1, CODE2, CODE3</p><p>" +
             "<span lang=\"fi\" class=\"multilang\">Kurssi</span><span lang=\"en\" class=\"multilang\">Course</span>" +
-            "<span lang=\"sv\" class=\"multilang\">Kurs</span>, "));
+            "<span lang=\"sv\" class=\"multilang\">Kurs</span></p>", moodleCourse.summary);
         assertEquals(LocalDate.now(), moodleCourse.startTime);
         assertEquals(LocalDate.now().plusYears(1), moodleCourse.endTime);
         assertEquals(MOODLE_DEFAULT_CATEGORY_ID, moodleCourse.categoryId);

--- a/src/test/java/fi/helsinki/moodi/web/AbstractSuccessfulCreateCourseTest.java
+++ b/src/test/java/fi/helsinki/moodi/web/AbstractSuccessfulCreateCourseTest.java
@@ -35,7 +35,7 @@ public abstract class AbstractSuccessfulCreateCourseTest extends AbstractMoodiIn
         "span%3E%3Cspan+lang%3D%22en%22+class%3D%22multilang%22%3ECourses%3C%2Fspan%3E%3Cspan+lang%3D%22sv%22+class%3D%22multilang%22%3E" +
         "Studieavsnitten%3C%2Fspan%3E+%3C%2Fp%3E%3Cp%3E%3Cspan+lang%3D%22fi%22+class%3D%22multilang%22%3EKurssi%3C%2Fspan%3E%3Cspan+lang%3D" +
         "%22en%22+class%3D%22multilang%22%3ECourse%3C%2Fspan%3E%3Cspan+lang%3D%22sv%22+class%3D%22multilang%22%3EKurs%3C%2Fspan%3E%2C+5.8.2019" +
-        "-5.12.2019%3C%2Fp%3E";
+        "%E2%80%935.11.2019%3C%2Fp%3E";
 
     protected void expectEnrollmentsWithAddedMoodiRoles(List<MoodleEnrollment> moodleEnrollments) {
         expectEnrollmentRequestToMoodle(moodleEnrollments.stream()


### PR DESCRIPTION
https://helsinkifi.slack.com/archives/C03G8SC69FH/p1655363894435549 , eli kurssikuvauksen pitäisi näyttää varsinaiset sisusta tulevat kurssin ajat, nyt näyttää ne muokatut ajat joita käytetään moodle-kurssin aukioloaikojen määrittämiseen, eli esim. se muutos että kurssi on moodlessa auki vielä +1kk päättymisen jälkeen.