### PR TITLE
MOODI-163 fetch moodle enrollments one by one if batch fails

### DIFF
--- a/src/main/java/fi/helsinki/moodi/integration/moodle/MoodleClient.java
+++ b/src/main/java/fi/helsinki/moodi/integration/moodle/MoodleClient.java
@@ -267,7 +267,8 @@ public class MoodleClient {
                 result = execute(params, new TypeReference<List<MoodleCourseWithEnrollments>>() {
                 }, DEFAULT_EVALUATION, true);
                 if (result != null && result.size() != batchCourseIds.size()) {
-                    throw new MoodleClientException("Received response with less courses (" + result.size() + ") than sent batchCourseIds: " + batchCourseIds.size(), "", "500");
+                    throw new MoodleClientException("Received response with less courses (" + result.size() +
+                        ") than sent batchCourseIds: " + batchCourseIds.size(), "", "500");
                 }
             } catch (Exception e) {
                 result = null;
@@ -293,7 +294,8 @@ public class MoodleClient {
                     }
                 }
                 if (errorsInBatch > 50) {
-                    handleException("Too many errors in one batch, abort: " + errorsInBatch + " (batch " + batchCounter + "/" + batches.size() + ")", e);
+                    handleException("Too many errors in one batch, abort: " + errorsInBatch + " (batch " + batchCounter +
+                        "/" + batches.size() + ")", e);
                 }
             }
             if (result != null) { // result.size() == batchCourseIds.size() always at this point

--- a/src/main/java/fi/helsinki/moodi/integration/moodle/MoodleService.java
+++ b/src/main/java/fi/helsinki/moodi/integration/moodle/MoodleService.java
@@ -21,6 +21,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 @Service
@@ -62,8 +63,8 @@ public class MoodleService {
         return moodleClient.getEnrolledUsers(courseId);
     }
 
-    public List<MoodleCourseWithEnrollments> getEnrolledUsers(final List<Long> courseIds) {
-        return moodleClient.getEnrolledUsersForCourses(courseIds);
+    public void fetchEnrolledUsersForCourses(final Map<Long, List<MoodleUserEnrollments>> enrolmentsByCourseId, final List<Long> courseIds) {
+        moodleClient.getEnrolledUsersForCourses(enrolmentsByCourseId, courseIds);
     }
 
     public void addRoles(final List<MoodleEnrollment> moodleEnrollments) {

--- a/src/main/java/fi/helsinki/moodi/service/synchronize/enrich/EnricherService.java
+++ b/src/main/java/fi/helsinki/moodi/service/synchronize/enrich/EnricherService.java
@@ -17,7 +17,6 @@
 
 package fi.helsinki.moodi.service.synchronize.enrich;
 
-import fi.helsinki.moodi.integration.moodle.MoodleCourseWithEnrollments;
 import fi.helsinki.moodi.integration.moodle.MoodleFullCourse;
 import fi.helsinki.moodi.integration.moodle.MoodleService;
 import fi.helsinki.moodi.integration.moodle.MoodleUser;

--- a/src/test/java/fi/helsinki/moodi/service/synchronize/enrich/EnricherServiceTest.java
+++ b/src/test/java/fi/helsinki/moodi/service/synchronize/enrich/EnricherServiceTest.java
@@ -137,7 +137,7 @@ public class EnricherServiceTest extends AbstractMoodiIntegrationTest  {
         prepareMoodleGetEnrolledUsersForCoursesMock(
             items.stream().map(item ->
                 new MoodleCourseWithEnrollments(item.getCourse().moodleId, Collections.emptyList())).collect(Collectors.toList()),
-        3);
+            3);
 
         List<SynchronizationItem> enrichedItems = enricherService.enrichItems(items);
 

--- a/src/test/java/fi/helsinki/moodi/test/AbstractMoodiIntegrationTest.java
+++ b/src/test/java/fi/helsinki/moodi/test/AbstractMoodiIntegrationTest.java
@@ -28,7 +28,6 @@ import fi.helsinki.moodi.integration.moodle.MoodleRole;
 import fi.helsinki.moodi.integration.moodle.MoodleUserEnrollments;
 import fi.helsinki.moodi.service.importing.ImportCourseRequest;
 import fi.helsinki.moodi.service.synchronize.enrich.EnricherService;
-import fi.helsinki.moodi.service.synchronize.enrich.EnrichmentStatus;
 import fi.helsinki.moodi.service.util.MapperService;
 import fi.helsinki.moodi.test.fixtures.Fixtures;
 import org.flywaydb.core.Flyway;


### PR DESCRIPTION
Korjaus siihen että synkronisointi epäonnistuu kun moodlesta haetaan kurssien osallistujia. Niitä on ehditty hakea 15 sadan kurssin otosta, kunnes 16. epäonnistuu. Muutetaan logiikkaa niin, että kun batch epäonnistuu, yritetään hakea sen kursseja 100 * yksi kerrallaan yhden 100 kpl satsin sijaan. Näistä kun osutaan siihen joka epäonnistuu, se ignoroidaan. Jos batchissa on yli 50 epäonnistumista, nostetaan errori joka lopettaa koko synkronisoinnin, jotta ei jäädä pommittamaan sekaisin/alhaalla olevaa moodlea.

Samalla on pitänyt muuttaa tapaa millä haettuja osallistumistietoja laitetaan talteen. Koska vastauksena saadaan lista listoja joissa ei ole mitään tietoa siitä mihin kurssiin mikäkin osallistujalista liittyi, ne käsiteltiin yhdessä lähetetyn ids-listan kanssa, jos kaikki kurssit haettiin ongelmitta niin haettujen id:iden lista vastasi tuloslistaa -- tulosten elementti n vastasi haettavien id:iden indeksiä n. Jos tuli ongelmia niin keskeytettiin koko synkronisointi koska tuosta vastaavuudesta ei enää voi olla varma jos välistä puuttuu jotain. Nyt tuo on muutettu niin, että aina kun saadaan ehjä sadan lista, sen jäsenet laitetaan batchIds -listan perusteella oikean kurssi-id:n taakse, mutta kun tulee tuollainen rikkinäinen satsi, niin siinä laitetaan osallistujat kurssi-id:n taakse yksi kerrallaan. Joillekin kurssi-id:lle ei tule mitään `prefetchedMoodleEnrollmentsByCourseId` -mäppäykseen.

Nyt ne joille ei löydy osallistujatietoja `prefetchedMoodleEnrollmentsByCourseId` enrichment-vaiheessa saavat enrichmentStatus.ERROR:n ja nämä ohitetaan synkronisointivaiheessa. Joten nämä joilta jää puuttumaan eivät synkronisoidu.

Tapahtumalogiin pitäisi nyt jäädä tarpeeksi meteliä silloin kun yksittäisen kurssin opiskelijatietojen haku epäonnistuu jotta pääsemme näkemään tarkalleen missä epäonnistuminen tapahtuu.

Tästä puuttuu testit.
