### PR TITLE
MOODI-161 api for sending make visible -calls to moodle

### DIFF
--- a/src/itest/java/fi/helsinki/moodi/moodle/MoodleIntegrationUpdateVisibilityTest.java
+++ b/src/itest/java/fi/helsinki/moodi/moodle/MoodleIntegrationUpdateVisibilityTest.java
@@ -1,0 +1,49 @@
+/*
+ * This file is part of Moodi application.
+ *
+ * Moodi application is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Moodi application is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Moodi application.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package fi.helsinki.moodi.moodle;
+
+import fi.helsinki.moodi.service.course.CourseService;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static com.google.common.collect.Lists.newArrayList;
+import static org.junit.Assert.assertTrue;
+
+public class MoodleIntegrationUpdateVisibilityTest extends AbstractMoodleIntegrationTest {
+
+    @Autowired
+    private CourseService courseService;
+
+    @Test
+    public void testMoodleIntegrationWhenUpdatingVisibility() {
+        String sisuCourseId = getSisuCourseId();
+
+        expectCreator(creatorUser);
+
+        expectCourseRealisationsWithUsers(
+            sisuCourseId,
+            newArrayList(studentUser, studentUserNotInMoodle),
+            newArrayList(teacherUser)
+        );
+
+        importCourse(sisuCourseId, creatorUser.personId);
+
+        boolean success = courseService.ensureCourseVisibility(sisuCourseId);
+        assertTrue(success);
+    }
+}

--- a/src/main/java/fi/helsinki/moodi/integration/moodle/MoodleClient.java
+++ b/src/main/java/fi/helsinki/moodi/integration/moodle/MoodleClient.java
@@ -309,6 +309,23 @@ public class MoodleClient {
         }
     }
 
+    public long updateCourseVisibility(final long courseId, final boolean visible) {
+        final MultiValueMap<String, String> params = createParametersForFunction("core_course_update_courses");
+        // courses[0][id]= courseId
+        // courses[0][visible]= int
+        params.set(createParamName(COURSES, "id", 0), String.valueOf(courseId));
+        params.set(createParamName(COURSES, "visible", 0), booleanToIntString(visible));
+        try {
+            return execute(params, new TypeReference<List<MoodleCourseData>>() {}, DEFAULT_EVALUATION, false)
+                .stream()
+                .findFirst()
+                .map(s -> s.id)
+                .orElse(null);
+        } catch (Exception e) {
+            return handleException("Error executing method: updateCourseVisibility", e);
+        }
+    }
+
     private MultiValueMap<String, String> createEnrolmentQueryParams(List<Long> batchCourseIds) {
         final MultiValueMap<String, String> params = createParametersForFunction("core_enrol_get_enrolled_users_with_capability");
         setListParameters(params, "coursecapabilities[%s][courseid]", batchCourseIds, String::valueOf);

--- a/src/main/java/fi/helsinki/moodi/integration/moodle/MoodleService.java
+++ b/src/main/java/fi/helsinki/moodi/integration/moodle/MoodleService.java
@@ -82,4 +82,8 @@ public class MoodleService {
     public void suspendEnrollments(final List<MoodleEnrollment> moodleEnrollments) {
         moodleClient.suspendEnrollments(moodleEnrollments);
     }
+
+    public Long updateCourseVisibility(final long courseId, boolean visible) {
+        return moodleClient.updateCourseVisibility(courseId, visible);
+    }
 }

--- a/src/main/java/fi/helsinki/moodi/web/CourseController.java
+++ b/src/main/java/fi/helsinki/moodi/web/CourseController.java
@@ -19,6 +19,7 @@ package fi.helsinki.moodi.web;
 
 import fi.helsinki.moodi.MoodiHealthIndicator;
 import fi.helsinki.moodi.service.Result;
+import fi.helsinki.moodi.service.course.CourseService;
 import fi.helsinki.moodi.service.dto.CourseDto;
 import fi.helsinki.moodi.service.importing.ImportCourseRequest;
 import fi.helsinki.moodi.service.importing.ImportCourseResponse;
@@ -34,15 +35,17 @@ import javax.validation.Valid;
 public class CourseController {
 
     private final ImportingService importingService;
+    private final CourseService courseService;
     private final MoodiHealthIndicator moodiHealthIndicator;
 
     @Autowired
-    public CourseController(ImportingService importingService, MoodiHealthIndicator moodiHealthIndicator) {
+    public CourseController(ImportingService importingService, CourseService courseService, MoodiHealthIndicator moodiHealthIndicator) {
         this.importingService = importingService;
+        this.courseService = courseService;
         this.moodiHealthIndicator = moodiHealthIndicator;
     }
 
-    @RequestMapping(value = "/api/v1/courses", method = RequestMethod.POST)
+    @PostMapping(value = "/api/v1/courses")
     public ResponseEntity<Result<ImportCourseResponse, String>> importCourse(
         @Valid @RequestBody final ImportCourseRequest request) {
 
@@ -56,11 +59,18 @@ public class CourseController {
         }
     }
 
-    @RequestMapping(value = "/api/v1/courses/{realisationId}", method = RequestMethod.GET)
+    @GetMapping(value = "/api/v1/courses/{realisationId}")
     public ResponseEntity<CourseDto> getCourse(
         @PathVariable("realisationId") String realisationId) {
 
         return response(importingService.getImportedCourse(realisationId));
+    }
+
+    @PostMapping(value = "/api/v1/courses/make_visible/{realisationId}")
+    public ResponseEntity<Boolean> makeVisible(
+        @PathVariable("realisationId") String realisationId) {
+
+        return response(courseService.ensureCourseVisibility(realisationId));
     }
 
     private <D, E> ResponseEntity<Result<D, E>> response(Result<D, E> result) {

--- a/src/test/java/fi/helsinki/moodi/web/EnsureCourseVisibilityTest.java
+++ b/src/test/java/fi/helsinki/moodi/web/EnsureCourseVisibilityTest.java
@@ -56,7 +56,7 @@ public class EnsureCourseVisibilityTest extends AbstractMoodiIntegrationTest {
             .andReturn();
         String content = result.getResponse().getContentAsString();
         assertEquals("true", content);
-   }
+    }
 
     @Test
     public void makeVisibleForNonexistingCourseReturnsNotFound() throws Exception {

--- a/src/test/java/fi/helsinki/moodi/web/EnsureCourseVisibilityTest.java
+++ b/src/test/java/fi/helsinki/moodi/web/EnsureCourseVisibilityTest.java
@@ -1,0 +1,60 @@
+/*
+ * This file is part of Moodi application.
+ *
+ * Moodi application is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Moodi application is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Moodi application.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package fi.helsinki.moodi.web;
+
+import fi.helsinki.moodi.test.AbstractMoodiIntegrationTest;
+import org.junit.Test;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.junit.Assert.assertEquals;
+import static org.hamcrest.Matchers.startsWith;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.content;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.header;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+public class EnsureCourseVisibilityTest extends AbstractMoodiIntegrationTest {
+    private void mockUpdateCourseVisibility(long moodleId) {
+        moodleMockServer.expect(requestTo(getMoodleRestUrl()))
+            .andExpect(method(HttpMethod.POST))
+            .andExpect(header("Content-Type", "application/x-www-form-urlencoded;charset=UTF-8"))
+            .andExpect(content().string(startsWith(
+                "wstoken=xxxx1234&wsfunction=core_course_update_courses&moodlewsrestformat=json")))
+            .andRespond(request -> withSuccess("[{\"id\":\"" + moodleId + "\", \"shortname\":\"shortie\"}]", MediaType.APPLICATION_JSON)
+            .createResponse(request));
+    }
+
+    @Test
+    public void successfulMakeVisibleReturnsCorrectResponse() throws Exception {
+        mockUpdateCourseVisibility(MOODLE_COURSE_ID_IN_DB);
+        MvcResult result = mockMvc.perform(
+            post("/api/v1/courses/make_visible/" + SISU_REALISATION_IN_DB_ID)
+                .contentType(MediaType.APPLICATION_JSON)
+                .header("client-id", "testclient")
+                .header("client-token", "xxx123")
+                ).andExpect(status().isOk())
+            .andReturn();
+        String content = result.getResponse().getContentAsString();
+        assertEquals("true", content);
+   }
+}

--- a/src/test/java/fi/helsinki/moodi/web/EnsureCourseVisibilityTest.java
+++ b/src/test/java/fi/helsinki/moodi/web/EnsureCourseVisibilityTest.java
@@ -57,4 +57,14 @@ public class EnsureCourseVisibilityTest extends AbstractMoodiIntegrationTest {
         String content = result.getResponse().getContentAsString();
         assertEquals("true", content);
    }
+
+    @Test
+    public void makeVisibleForNonexistingCourseReturnsNotFound() throws Exception {
+        mockMvc.perform(
+                post("/api/v1/courses/make_visible/" + SISU_REALISATION_NOT_IN_DB_ID)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .header("client-id", "testclient")
+                    .header("client-token", "xxx123")
+            ).andExpect(status().isNotFound());
+    }
 }


### PR DESCRIPTION
Tässä tehty api POST ${moodihost}/api/v1/courses/make_visible/${sisu_cur_id}  jolla tökätään moodlessa kyseinen kurssi näkyväksi jos se löytyy moodista ja moodlesta.
Toimivuutta pääsee testaamaan kunnolla vasta kun QA:lla, tullee jotain lisäsäätöä. 