### PR TITLE
MOODI-167: alustava toteutus synchronize-groups endpointille

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,41 +1,40 @@
-Moodi
-================
+# Moodi
 
 Moodi is an integration application that automates course creation and user enrollment to Moodle based on master data from Sisu.
 
-Integrations
-================
+## Integrations
 
 - Sisu (Master data source for courses and course students and teachers)
 - Moodle (Target for modification operations by Moodi. Course spaces are created and users are 
 enrolled via Moodle api by Moodi application)
 
-Environments
-================
+## Environments
 
-Currently Moodi has 3 environments: local, dev, and prod. Integrations are mapped for each environment in corresponding application-<env>.yml. 
+Currently Moodi has 4 environments: local, local_docker, dev, and prod. Integrations are mapped for each environment in corresponding application-<env>.yml. local_docker is meant to be used with the [dockerized development environment] (https://github.com/UH-StudentServices/moodi-development) (see below).
 
-Requirements
----------------
+## Requirements
 
-The following programs must be installed:
+The following programs must be installed if not using the dockerized development environment:
 - JDK 8
 
-Local development
----------------
+# Local development
 
 This is an integration application and as such running locally requires a lot of setup work with ssh tunnels, certificates etc. The 
 recommended way to test changes to the application locally is by running automated tests. Therefore good automated test coverage is essential
 when new features are added.
 
-### Running tests
+You can use also the [dockerized development environment](https://github.com/UH-StudentServices/moodi-development) to run the application with Moodle locally (see below for more information).
+
+## Running tests
+
 ```sh
 ./gradlew test
 # or
 ./gradlew test_psql # To run against a local Dockerized Postgres, see below.
 ```
 
-### Running Moodi-Moodle integration tests
+## Running Moodi-Moodle integration tests
+
 This is normally done in Jenkins, but if you want to test something locally, you need to go through 
 an ssh tunnel via moodi-dev, because the Moodle API has an IP restriction in place.
 
@@ -55,8 +54,10 @@ read MOODLE_WS_TOKEN
 ./gradlew itest --rerun-tasks -Pmoodle_base_url=https://moodi-2-moodle-20.student.helsinki.fi:1444/moodlecurrent/webservice/rest/server.php -Pmoodle_ws_token=$MOODLE_WS_TOKEN   
 ```
 
-### Running Moodi locally
-#### Prerequisites
+## Running Moodi locally
+
+### Prerequisites
+
 Open an ssh tunnel to call Sisu through the test API GW and the Moodle API:
 ```
 ssh  moodi-1.student.helsinki.fi -L 1443:gw-api-test.it.helsinki.fi:443 -L 1444:moodi-2-moodle-20.student.helsinki.fi:443
@@ -86,25 +87,41 @@ application-dev.yml:
     apiKey: <see https://api-test.it.helsinki.fi/portal/applications/f2d7ede8-2810-4a1e-97ed-e828100a1e4a/subscriptions?subscription=e959b407-023e-499a-99b4-07023e399adb#s>
 ```
 
-#### Starting Moodi
+### Starting Moodi
+
 ```sh
 ./gradlew bootRun
 ```
 The test UI is now available at http://localhost:8084/login
 Credentials are: user/password
 
-#### Cleaning up
+### Cleaning up
+
 - Comment out the line in /etc/hosts.
 - Delete local moodi.p12
 - Remove the keystore password and Moodle token from ~/moodi/moodi.properties
 
+### Fully dockerized development environment
+
+There is a separate project for running the whole application in Docker containers. See
+<https://github.com/UH-StudentServices/moodi-development> for more information.
+
+In this project there is few additions to support the dockerized environment:
+- `app.Dockerfile` contains the Dockerfile for the Java app. It is not directly usable without the docker-compose.yml in the moodi-development project.
+- `src/main/resources/config/application-local_docker.yml` contains the configuration for the app when running in the dockerized environment.
+
+To make the `app.Dockerfile` file more flexible a configuration file should support setting configuration
+related to external services (API-GW, Moodle) via environment variables either by developing moodi-development project further or by adding a new configuration file for this purpose. Also some settings could be moved to
+`moodi.properties` file for supporting the easier configuration of the app.
+
 # Database
 
-
 ## Servers
+
 The server environments use Postgres 9.4.
 
 ## Local
+
 The local environment and tests use a H2 database. 
 
 ### Dockerized local Postgres
@@ -124,8 +141,8 @@ To clear the data, first stop the container and then:
 docker rm moodi-postgres
 docker volume rm moodi-app_moodi-postgres-data 
 ```
-To create a new dump:
 
+To create a new dump:
 ```
 ssh moodi-1.student.helsinki.fi
 sudo su - postgres

--- a/app.Dockerfile
+++ b/app.Dockerfile
@@ -1,0 +1,20 @@
+# This file is meant to be used for dockerized local development and testing with
+# https://github.com/UH-StudentServices/moodi-development project.
+FROM gradle:7.4-jdk8
+
+WORKDIR /app
+
+# Copy the Gradle configuration files to download dependencies
+COPY build.gradle gradlew gradle.properties /app/
+COPY gradle /app/gradle
+COPY gradle-build /app/gradle-build
+
+# Download dependencies as a separate step to leverage Docker caching
+RUN gradle build --exclude-task test --continue --no-daemon
+
+# Copy the rest of the code
+COPY . /app
+
+EXPOSE 8080
+
+CMD gradle bootRun --no-daemon --args="--spring.profiles.active=local_docker"

--- a/build.gradle
+++ b/build.gradle
@@ -81,6 +81,7 @@ if(hasProperty("opintoni_artifactory_base_url")) {
 }
 
 dependencies {
+    developmentOnly 'org.springframework.boot:spring-boot-devtools'
 
     implementation('org.springframework.boot:spring-boot-starter-web') {
         exclude module: 'spring-boot-starter-tomcat'

--- a/src/main/java/fi/helsinki/moodi/config/RemoteServerDeploymentCondition.java
+++ b/src/main/java/fi/helsinki/moodi/config/RemoteServerDeploymentCondition.java
@@ -25,6 +25,6 @@ public final class RemoteServerDeploymentCondition implements Condition {
 
     @Override
     public boolean matches(ConditionContext context, AnnotatedTypeMetadata metadata) {
-        return context.getEnvironment().acceptsProfiles("dev", "prod");
+        return context.getEnvironment().acceptsProfiles("dev", "prod", "local_docker");
     }
 }

--- a/src/main/java/fi/helsinki/moodi/exception/MoodleCourseNotFoundException.java
+++ b/src/main/java/fi/helsinki/moodi/exception/MoodleCourseNotFoundException.java
@@ -1,0 +1,25 @@
+/*
+ * This file is part of Moodi application.
+ *
+ * Moodi application is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Moodi application is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Moodi application.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package fi.helsinki.moodi.exception;
+
+// Indicates a course is not found in Moodi.
+public class MoodleCourseNotFoundException extends MoodiException {
+    public MoodleCourseNotFoundException(Long courseId) {
+        super(String.format("Moodle course with courseId %s not found", courseId));
+    }
+}

--- a/src/main/java/fi/helsinki/moodi/integration/moodle/MoodleService.java
+++ b/src/main/java/fi/helsinki/moodi/integration/moodle/MoodleService.java
@@ -20,6 +20,8 @@ package fi.helsinki.moodi.integration.moodle;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import javax.validation.constraints.NotNull;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -57,6 +59,10 @@ public class MoodleService {
 
     public List<MoodleFullCourse> getCourses(final List<Long> courseIds) {
         return moodleClient.getCourses(courseIds);
+    }
+
+    public Optional<MoodleFullCourse> getCourse(@NotNull Long courseId) {
+        return this.getCourses(Collections.singletonList(courseId)).stream().findFirst();
     }
 
     public List<MoodleUserEnrollments> getEnrolledUsers(final long courseId) {

--- a/src/main/java/fi/helsinki/moodi/integration/sisu/SisuClient.java
+++ b/src/main/java/fi/helsinki/moodi/integration/sisu/SisuClient.java
@@ -18,11 +18,7 @@
 package fi.helsinki.moodi.integration.sisu;
 
 import fi.helsinki.moodi.exception.IntegrationConnectionException;
-import io.aexp.nodes.graphql.Argument;
-import io.aexp.nodes.graphql.Arguments;
-import io.aexp.nodes.graphql.GraphQLRequestEntity;
-import io.aexp.nodes.graphql.GraphQLResponseEntity;
-import io.aexp.nodes.graphql.GraphQLTemplate;
+import io.aexp.nodes.graphql.*;
 import io.aexp.nodes.graphql.exceptions.GraphQLException;
 import io.aexp.nodes.graphql.internal.Error;
 import org.slf4j.Logger;
@@ -39,13 +35,7 @@ import org.springframework.web.client.RestOperations;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
@@ -99,6 +89,13 @@ public class SisuClient {
             }
         }
         return ret;
+    }
+
+    public Optional<SisuCourseUnitRealisation> getCourseUnitRealisation(final String id) {
+        if (id == null) {
+            return Optional.empty();
+        }
+        return this.getCourseUnitRealisations(Collections.singletonList(id)).stream().findFirst();
     }
 
     @Cacheable(value = "sisu-client.organisations-by-id", unless = "#result == null or #result.size()==0")

--- a/src/main/java/fi/helsinki/moodi/integration/sisu/SisuCourseUnitRealisation.java
+++ b/src/main/java/fi/helsinki/moodi/integration/sisu/SisuCourseUnitRealisation.java
@@ -26,12 +26,7 @@ import io.micrometer.core.instrument.util.StringUtils;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import static fi.helsinki.moodi.Constants.RESPONSIBLE_ORGANISATION;
@@ -69,6 +64,7 @@ public class SisuCourseUnitRealisation {
     public String teachingLanguageUrn;
     public List<SisuLearningEnvironment> learningEnvironments = new ArrayList<>();
     public List<SisuResponsibilityInfo> responsibilityInfos = new ArrayList<>();
+    public List<SisuStudyGroupSet> studyGroupSets = new ArrayList<>();
     public List<SisuEnrolment> enrolments = new ArrayList<>();
     public List<SisuOrganisationRoleShare> organisations = new ArrayList<>();
     public List<SisuCourseUnit> courseUnits = new ArrayList<>();

--- a/src/main/java/fi/helsinki/moodi/integration/sisu/SisuStudyGroupSet.java
+++ b/src/main/java/fi/helsinki/moodi/integration/sisu/SisuStudyGroupSet.java
@@ -19,28 +19,8 @@ package fi.helsinki.moodi.integration.sisu;
 
 import java.util.List;
 
-public class SisuEnrolment {
-
-    public EnrolmentState state;
-    public SisuPerson person;
-    public List<String> confirmedStudySubGroupIds;
-
-    public SisuEnrolment() {
-    }
-
-    public SisuEnrolment(EnrolmentState state, SisuPerson person, List<String> confirmedStudySubGroupIds) {
-        this.state = state;
-        this.person = person;
-        this.confirmedStudySubGroupIds = confirmedStudySubGroupIds;
-    }
-
-    public boolean isEnrolled() {
-        return EnrolmentState.ENROLLED.equals(state);
-    }
-
-    public enum EnrolmentState {
-        NOT_ENROLLED, PROCESSING, RESERVED,
-        CONFIRMED, ENROLLED, REJECTED,
-        ABORTED_BY_STUDENT, ABORTED_BY_TEACHER
-    }
+public class SisuStudyGroupSet {
+    public String localId;
+    public SisuLocalisedValue name;
+    public List<SisuStudySubGroup> studySubGroups;
 }

--- a/src/main/java/fi/helsinki/moodi/integration/sisu/SisuStudySubGroup.java
+++ b/src/main/java/fi/helsinki/moodi/integration/sisu/SisuStudySubGroup.java
@@ -17,30 +17,7 @@
 
 package fi.helsinki.moodi.integration.sisu;
 
-import java.util.List;
-
-public class SisuEnrolment {
-
-    public EnrolmentState state;
-    public SisuPerson person;
-    public List<String> confirmedStudySubGroupIds;
-
-    public SisuEnrolment() {
-    }
-
-    public SisuEnrolment(EnrolmentState state, SisuPerson person, List<String> confirmedStudySubGroupIds) {
-        this.state = state;
-        this.person = person;
-        this.confirmedStudySubGroupIds = confirmedStudySubGroupIds;
-    }
-
-    public boolean isEnrolled() {
-        return EnrolmentState.ENROLLED.equals(state);
-    }
-
-    public enum EnrolmentState {
-        NOT_ENROLLED, PROCESSING, RESERVED,
-        CONFIRMED, ENROLLED, REJECTED,
-        ABORTED_BY_STUDENT, ABORTED_BY_TEACHER
-    }
+public class SisuStudySubGroup {
+    public String id;
+    public SisuLocalisedValue name;
 }

--- a/src/main/java/fi/helsinki/moodi/service/course/group/GroupSynchronizationService.java
+++ b/src/main/java/fi/helsinki/moodi/service/course/group/GroupSynchronizationService.java
@@ -1,0 +1,66 @@
+/*
+ * This file is part of Moodi application.
+ *
+ * Moodi application is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Moodi application is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Moodi application.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package fi.helsinki.moodi.service.course.group;
+
+import fi.helsinki.moodi.exception.CourseNotFoundException;
+import fi.helsinki.moodi.exception.MoodleCourseNotFoundException;
+import fi.helsinki.moodi.integration.moodle.MoodleFullCourse;
+import fi.helsinki.moodi.integration.moodle.MoodleService;
+import fi.helsinki.moodi.integration.sisu.SisuClient;
+import fi.helsinki.moodi.integration.sisu.SisuCourseUnitRealisation;
+import fi.helsinki.moodi.service.course.Course;
+import fi.helsinki.moodi.service.course.CourseService;
+import org.springframework.stereotype.Service;
+
+import javax.validation.constraints.NotNull;
+import java.util.Optional;
+
+@Service
+public class GroupSynchronizationService {
+
+    private final CourseService courseService;
+    private final MoodleService moodleService;
+    private final SisuClient sisuClient;
+
+    public GroupSynchronizationService(CourseService courseService, MoodleService moodleService, SisuClient sisuClient) {
+        this.courseService = courseService;
+        this.moodleService = moodleService;
+        this.sisuClient = sisuClient;
+    }
+
+    // TODO: MOODI-168
+    public SynchronizeGroupsResponse synchronizeGroups(@NotNull String realisationId) {
+        final Optional<SisuCourseUnitRealisation> existingRealisation = sisuClient.getCourseUnitRealisation(realisationId);
+        if (!existingRealisation.isPresent()) {
+            throw new CourseNotFoundException(realisationId);
+        }
+        SisuCourseUnitRealisation realisation = existingRealisation.get();
+        final Optional<Course> existingCourse = courseService.findByRealisationId(realisationId);
+        if (!existingCourse.isPresent()) {
+            throw new CourseNotFoundException(realisationId);
+        }
+
+        final Course course = existingCourse.get();
+        final Optional<MoodleFullCourse> moodleCourse = moodleService.getCourse(course.moodleId);
+        if (!moodleCourse.isPresent()) {
+            throw new MoodleCourseNotFoundException(course.moodleId);
+        }
+
+        return new SynchronizeGroupsResponse(realisation);
+    }
+}

--- a/src/main/java/fi/helsinki/moodi/service/course/group/SynchronizeGroupsResponse.java
+++ b/src/main/java/fi/helsinki/moodi/service/course/group/SynchronizeGroupsResponse.java
@@ -1,0 +1,61 @@
+/*
+ * This file is part of Moodi application.
+ *
+ * Moodi application is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Moodi application is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Moodi application.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package fi.helsinki.moodi.service.course.group;
+
+import fi.helsinki.moodi.integration.sisu.SisuCourseUnitRealisation;
+import fi.helsinki.moodi.integration.sisu.SisuLocalisedValue;
+
+import java.util.*;
+
+public final class SynchronizeGroupsResponse {
+    public static class StudySubGroup {
+        public String id;
+        public SisuLocalisedValue name;
+        public List<String> personIds;
+        public SisuLocalisedValue studyGroupSetName;
+        public String studyGroupSetId;
+    }
+
+    public List<StudySubGroup> studySubGroups;
+
+    public SynchronizeGroupsResponse(SisuCourseUnitRealisation realisation) {
+        Map<String, Set<String>> personIdsByStudySubGroupId = new HashMap<>();
+        studySubGroups = new ArrayList<>();
+
+        realisation.enrolments.forEach(enrolment -> {
+            enrolment.confirmedStudySubGroupIds.forEach(subGroup -> {
+                if (!personIdsByStudySubGroupId.containsKey(subGroup)) {
+                    personIdsByStudySubGroupId.put(subGroup, new HashSet<>());
+                }
+                personIdsByStudySubGroupId.get(subGroup).add(enrolment.person.id);
+            });
+        });
+        realisation.studyGroupSets.forEach(set -> {
+            set.studySubGroups.forEach(subGroup -> {
+                StudySubGroup studySubGroup = new StudySubGroup();
+                studySubGroup.id = subGroup.id;
+                studySubGroup.name = subGroup.name;
+                studySubGroup.studyGroupSetName = set.name;
+                studySubGroup.studyGroupSetId = set.localId;
+                studySubGroup.personIds = new ArrayList<>(personIdsByStudySubGroupId.getOrDefault(subGroup.id, new HashSet<>()));
+                studySubGroups.add(studySubGroup);
+            });
+        });
+
+    }
+}

--- a/src/main/java/fi/helsinki/moodi/web/CourseController.java
+++ b/src/main/java/fi/helsinki/moodi/web/CourseController.java
@@ -20,6 +20,8 @@ package fi.helsinki.moodi.web;
 import fi.helsinki.moodi.MoodiHealthIndicator;
 import fi.helsinki.moodi.service.Result;
 import fi.helsinki.moodi.service.course.CourseService;
+import fi.helsinki.moodi.service.course.group.GroupSynchronizationService;
+import fi.helsinki.moodi.service.course.group.SynchronizeGroupsResponse;
 import fi.helsinki.moodi.service.dto.CourseDto;
 import fi.helsinki.moodi.service.importing.ImportCourseRequest;
 import fi.helsinki.moodi.service.importing.ImportCourseResponse;
@@ -37,12 +39,19 @@ public class CourseController {
     private final ImportingService importingService;
     private final CourseService courseService;
     private final MoodiHealthIndicator moodiHealthIndicator;
+    private final GroupSynchronizationService groupSynchronizationService;
 
     @Autowired
-    public CourseController(ImportingService importingService, CourseService courseService, MoodiHealthIndicator moodiHealthIndicator) {
+    public CourseController(
+        ImportingService importingService,
+        CourseService courseService,
+        MoodiHealthIndicator moodiHealthIndicator,
+        GroupSynchronizationService groupSynchronizationService
+    ) {
         this.importingService = importingService;
         this.courseService = courseService;
         this.moodiHealthIndicator = moodiHealthIndicator;
+        this.groupSynchronizationService = groupSynchronizationService;
     }
 
     @PostMapping(value = "/api/v1/courses")
@@ -71,6 +80,12 @@ public class CourseController {
         @PathVariable("realisationId") String realisationId) {
 
         return response(courseService.ensureCourseVisibility(realisationId));
+    }
+
+    @PostMapping(value = "/api/v1/courses/{realisationId}/synchronize-groups")
+    public ResponseEntity<SynchronizeGroupsResponse> synchronizeGroups(
+        @PathVariable("realisationId") String realisationId) {
+        return response(groupSynchronizationService.synchronizeGroups(realisationId));
     }
 
     private <D, E> ResponseEntity<Result<D, E>> response(Result<D, E> result) {

--- a/src/main/resources/config/application-local_docker.yml
+++ b/src/main/resources/config/application-local_docker.yml
@@ -1,0 +1,33 @@
+spring:
+  datasource:
+    dataSourceClassName: org.postgresql.ds.PGSimpleDataSource
+    url: jdbc:postgresql://postgres-moodi:5432/moodi
+    username: moodi
+    password: moodi
+  jpa:
+    database-platform: org.hibernate.dialect.PostgreSQLDialect
+    database: PostgreSQL
+  flyway:
+    locations: classpath:db/migration/common,classpath:db/migration/psql
+    table: schema_version
+    ignore-missing-migrations: true
+    validateOnMigrate: false
+
+integration:
+  moodle:
+    baseUrl: http://local.moodle.helsinki.fi
+  sisu:
+    baseUrl: https://gw-api-test.it.helsinki.fi/secure/sisu
+    apiKey: ${apiGatewayApiKey}
+
+auth.client.user: 123456
+auth.enabled: false
+
+dev.mode.enabled: true
+
+synchronize.FULL.enabled: false
+synchronize.INCREMENTAL.enabled: false
+
+logging:
+  retain-logs: PT30M
+  file-logging-path: /tmp/log/moodi-import-sync-log

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -48,6 +48,13 @@
         <logger name="fi.helsinki.moodi" level="DEBUG"/>
     </springProfile>
 
+    <springProfile name="local_docker">
+        <root level="INFO">
+            <appender-ref ref="CONSOLE"/>
+        </root>
+        <logger name="fi.helsinki.moodi" level="DEBUG"/>
+    </springProfile>
+
     <springProfile name="test">
         <root level="INFO">
             <appender-ref ref="CONSOLE"/>
@@ -56,7 +63,7 @@
         <logger name="fi.helsinki.moodi.test" level="TRACE"/>
     </springProfile>
 
-    <springProfile name="local, test">
+    <springProfile name="local, test, local_docker">
         <logger name="SUMMARY_LOGGER" level="INFO">
             <appender-ref ref="CONSOLE"/>
         </logger>


### PR DESCRIPTION
Tämä PR lisää `api/v1/courses/CUR_ID/synchronize-groups` -endpointin tiketin speksien mukaisesti. Voi testata esim:
```
curl --location --request POST 'http://local.moodi.helsinki.fi/api/v1/courses/hy-opt-cur-2223-4abe1d07-2b71-496f-82f3-23022477ae66/synchronize-groups'
```
Kirjoittelen tarkemmat kommentit tiketille. 