### PR TITLE
MOODI-171: Moodle-virheiden käsittelyn korjaus

### DIFF
--- a/app.Dockerfile
+++ b/app.Dockerfile
@@ -1,6 +1,6 @@
 # This file is meant to be used for dockerized local development and testing with
 # https://github.com/UH-StudentServices/moodi-development project.
-FROM gradle:7.4-jdk8
+FROM gradle:7.6-jdk11
 
 WORKDIR /app
 

--- a/app.Dockerfile
+++ b/app.Dockerfile
@@ -2,6 +2,8 @@
 # https://github.com/UH-StudentServices/moodi-development project.
 FROM gradle:7.6-jdk11
 
+USER gradle
+
 WORKDIR /app
 
 # Copy the Gradle configuration files to download dependencies
@@ -10,11 +12,11 @@ COPY gradle /app/gradle
 COPY gradle-build /app/gradle-build
 
 # Download dependencies as a separate step to leverage Docker caching
-RUN gradle build --exclude-task test --continue --no-daemon
+RUN gradle build -g /home/gradle --exclude-task test --continue --no-daemon
 
 # Copy the rest of the code
 COPY . /app
 
 EXPOSE 8080
 
-CMD gradle bootRun --no-daemon --args="--spring.profiles.active=local_docker"
+CMD gradle bootRun -g /home/gradle --no-daemon --args="--spring.profiles.active=local_docker"

--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,18 @@ plugins {
     id "java"
     id 'checkstyle'
     id 'org.sonarqube' version '3.3'
+    id "io.sentry.jvm.gradle" version "3.14.0"
+}
+
+sentry {
+    // Generates a JVM (Java, Kotlin, etc.) source bundle and uploads your source code to Sentry.
+    // This enables source context, allowing you to see your source
+    // code as part of your stack traces in Sentry.
+    includeSourceContext = true
+
+    org = "university-of-helsinki-0p"
+    projectName = "moodi"
+    authToken = System.getenv("SENTRY_AUTH_TOKEN")
 }
 
 java {
@@ -130,8 +142,9 @@ dependencies {
     implementation 'org.trimou:trimou-core:2.5.1.Final'
     implementation "javax.mail:mail:1.4.7"
     implementation "javax.validation:validation-api:2.0.1.Final"
-
     implementation group: 'com.github.americanexpress.nodes', name: 'nodes', version: nodes_version
+    implementation 'io.sentry:sentry-spring-boot-starter:6.33.0'
+    implementation 'io.sentry:sentry-logback:6.33.0'
 
     testImplementation 'com.h2database:h2:2.1.212'
     testImplementation "org.springframework.boot:spring-boot-starter-test"

--- a/build.gradle
+++ b/build.gradle
@@ -30,8 +30,8 @@ plugins {
 }
 
 java {
-    sourceCompatibility = "1.8"
-    targetCompatibility = "1.8"
+    sourceCompatibility = "1.11"
+    targetCompatibility = "1.11"
 }
 
 apply plugin: "io.spring.dependency-management"
@@ -48,12 +48,36 @@ bootJar {
     launchScript()
 }
 
+bootRun {
+    if (project.hasProperty('debugMode')) {
+        debugOptions {
+            enabled = true
+            host = '*'
+            port = 5005
+            server = true
+            suspend = false
+        }
+    }
+}
+
 springBoot {
     mainClass = "fi.helsinki.moodi.Application"
 }
 
+test {
+    if (project.hasProperty('debugMode')) {
+        debugOptions {
+            enabled = true
+            host = '*'
+            port = 5005
+            server = true
+            suspend = true
+        }
+    }
+}
+
 wrapper {
-    gradleVersion = '7.4'
+    gradleVersion = '7.6'
 }
 
 checkstyle {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/fi/helsinki/moodi/web/GlobalExceptionHandler.java
+++ b/src/main/java/fi/helsinki/moodi/web/GlobalExceptionHandler.java
@@ -18,6 +18,7 @@
 package fi.helsinki.moodi.web;
 
 import fi.helsinki.moodi.exception.*;
+import fi.helsinki.moodi.integration.moodle.MoodleClientException;
 import fi.helsinki.moodi.service.Result;
 import org.slf4j.Logger;
 import org.springframework.http.HttpStatus;
@@ -25,6 +26,11 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.slf4j.LoggerFactory.getLogger;
 
@@ -55,21 +61,48 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
         return new ResponseEntity(Result.error(e.getMessage(), STATUS_NOT_FOUND, e.getMessage()), HttpStatus.NOT_FOUND);
     }
 
+    @ExceptionHandler(value = CourseAlreadyCreatedException.class)
+    public ResponseEntity<Result<?, String>> handleCourseAlreadyCreatedException(CourseAlreadyCreatedException e) {
+        logger.error(e.getMessage());
+        return new ResponseEntity<>(Result.error(e.getMessage(), STATUS_ERROR, e.getMessage()), HttpStatus.CONFLICT);
+    }
+
     @ExceptionHandler(value = MoodiException.class)
     public ResponseEntity<Result<?, String>> handleMoodiException(MoodiException e) {
         logger.error("Caught an exception", e);
-        return new ResponseEntity(Result.error("Error", STATUS_ERROR, e.getMessage()), HttpStatus.BAD_REQUEST);
+        return new ResponseEntity<>(Result.error("Error", STATUS_ERROR, e.getMessage()), HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(value = MoodleClientException.class)
+    public ResponseEntity<Result<?, String>> handleMoodleClientException(MoodleClientException e) {
+        logger.error("Caught an exception", e);
+        String error;
+        String message;
+        if (e.getCause() != null) {
+            error = e.getMessage();
+            message = Optional.of(e.getCause().getMessage()).orElse("");
+        } else {
+            error = Optional.of(e.getErrorCode()).orElse("");
+            message = Stream.of(e.getMoodleException(), e.getMessage()).filter(Objects::nonNull).collect(Collectors.joining(" "));
+        }
+        return new ResponseEntity<>(
+            Result.error(
+                error,
+                STATUS_ERROR,
+                message
+            ),
+            HttpStatus.INTERNAL_SERVER_ERROR);
     }
 
     @ExceptionHandler(value = UnauthorizedException.class)
     public ResponseEntity<Result<?, String>> handleUnauthorizedException(Exception e) {
         logger.warn("Unauthorized. " + e);
-        return new ResponseEntity(Result.error("Error", STATUS_ERROR, e.getMessage()), HttpStatus.UNAUTHORIZED);
+        return new ResponseEntity<>(Result.error("Error", STATUS_ERROR, e.getMessage()), HttpStatus.UNAUTHORIZED);
     }
 
     @ExceptionHandler(value = Exception.class)
     public ResponseEntity<Result<?, String>> handleException(Exception e) {
         logger.error("Caught an exception", e);
-        return new ResponseEntity(Result.error("Error", STATUS_ERROR, "Internal server error"), HttpStatus.INTERNAL_SERVER_ERROR);
+        return new ResponseEntity<>(Result.error("Error", STATUS_ERROR, "Internal server error"), HttpStatus.INTERNAL_SERVER_ERROR);
     }
 }

--- a/src/main/resources/config/application-local_docker.yml
+++ b/src/main/resources/config/application-local_docker.yml
@@ -29,5 +29,7 @@ synchronize.FULL.enabled: false
 synchronize.INCREMENTAL.enabled: false
 
 logging:
-  retain-logs: PT30M
-  file-logging-path: /tmp/log/moodi-import-sync-log
+  level:
+    root: INFO
+    fi.helsinki.moodi: DEBUG
+

--- a/src/main/resources/config/application.yml
+++ b/src/main/resources/config/application.yml
@@ -76,3 +76,8 @@ syncTresholds:
 mailNotification:
   from: moodi-app
   lockedMessageSubject: Synchronization locked
+
+sentry:
+    enabled: ${sentryEnabled:false}
+    environment: ${sentryEnvironment:dev}
+    dsn: ${sentryDsn:-}

--- a/src/test/java/fi/helsinki/moodi/web/CreateCourseTest.java
+++ b/src/test/java/fi/helsinki/moodi/web/CreateCourseTest.java
@@ -79,7 +79,7 @@ public class CreateCourseTest extends AbstractSuccessfulCreateCourseTest {
         // First try.
         makeCreateCourseRequest(SISU_REALISATION_NOT_IN_DB_ID)
             // Why return client error when Moodle is broken? I don't know, but not touching that right now.
-            .andExpect(status().is4xxClientError());
+            .andExpect(status().is5xxServerError());
 
         try {
             importingService.getImportedCourse(SISU_REALISATION_NOT_IN_DB_ID);


### PR DESCRIPTION
Tällä hetkellä Moodle-palauttamia virheitä ei logiteta oikein. Tämä pulla lisää tuen Moodlen exceptioneiden käsittelyllä. Samalla Moodle-integraatioiden virheiden käsittelyä on yksinkertaistettu (poistettu erillinen evaluaattori-toiminnallisuus).  Tämä pitää mergetä synkassa moodi-infra-muutosten kanssa, joten hoidan itse, kun tämä valmis.  Pullan yhteydessä Java päivitetään versioon 11 ja Gradle 7.4:stä 7.6:een ja tuki Sentrylle lisätään. 